### PR TITLE
github: add CI with badge in README.md, set C and CXX compiler for msvc-*

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build-windows:
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [msvc-debug, msvc-release, clang-debug]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Install Conan
+      run: pip install conan
+    - name: Configure with CMakeSettings.json and build
+      uses: lukka/run-cmake@v3
+      with:
+        cmakeListsOrSettingsJson: CMakeSettingsJson
+        cmakeSettingsJsonPath: '${{ github.workspace }}/CMakeSettings.json'
+        useVcpkgToolchainFile: false
+        buildDirectory: '${{ github.workspace }}/build'
+        configurationRegexFilter: '${{ matrix.configuration }}'
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: storm-engine.${{ matrix.configuration }}
+        path: build\${{ matrix.configuration }}\bin

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -6,7 +6,7 @@
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "",
+      "cmakeCommandArgs": "-DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl",
       "buildCommandArgs": "",
       "enableClangTidyCodeAnalysis": true,
       "variables": []
@@ -17,7 +17,7 @@
       "configurationType": "Release",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\build\\${name}",
-      "cmakeCommandArgs": "",
+      "cmakeCommandArgs": "-DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl",
       "buildCommandArgs": "",
       "enableClangTidyCodeAnalysis": true,
       "variables": []

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Storm-Engine
 Game engine behind the [Sea Dogs](https://en.wikipedia.org/wiki/Sea_Dogs_(video_game)) game series.
 
-[![Join the chat at https://discord.gg/jmwETPGFRe](https://img.shields.io/discord/353218868896071692?color=%237289DA&label=storm-devs&logo=discord&logoColor=white)](https://discord.gg/jmwETPGFRe)
+[![Join the chat at https://discord.gg/jmwETPGFRe](https://img.shields.io/discord/353218868896071692?color=%237289DA&label=storm-devs&logo=discord&logoColor=white)](https://discord.gg/jmwETPGFRe) [![GitHub Actions Build Status](https://github.com/storm-devs/storm-engine/actions/workflows/cibuild.yml/badge.svg)](https://github.com/storm-devs/storm-engine/actions/workflows/cibuild.yml)
 
  * [GitHub Discussions](https://github.com/storm-devs/storm-engine/discussions)
  * [Discord Chat](https://discord.gg/jmwETPGFRe)


### PR DESCRIPTION
It is github actions (CI) for build `msvc-debug`, `msvc-release` and `clang-debug`.

I need to set `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` for all configs from `CMakeSettings.json` because of this "bug / feature", which `github` don't want to fix: [CMake+Ninja detects GCC as the default compiler on Windows](https://github.com/actions/virtual-environments/issues/1621)

Here is how badge will looks after merge, but in PR it's pointing on https://github.com/storm-devs/storm-engine :
[![GitHub Actions Build Status](https://github.com/q4a/storm-engine/actions/workflows/cibuild.yml/badge.svg)](https://github.com/q4a/storm-engine/actions/workflows/cibuild.yml)
