### PR TITLE
Remove threaded function queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-﻿build
+﻿/build/
+/cmake-build-*/
+
 .vs
+.idea
+

--- a/src/apps/ENGINE/Main.cpp
+++ b/src/apps/ENGINE/Main.cpp
@@ -154,7 +154,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
                 //                if (!isHold && !core.Run())
                 if (!isHold && !runResult)
                 {
-                    core.CleanUp();
                     isHold = true;
                     SendMessage(hwnd, WM_CLOSE, 0, 0L);
                 }

--- a/src/apps/ENGINE/internal_functions.cpp
+++ b/src/apps/ENGINE/internal_functions.cpp
@@ -114,7 +114,6 @@ enum FUNCTION_CODE
     FUNC_GET_DLC_DATA,
     FUNC_DLC_START_OVERLAY,
     FUNC_GET_STEAM_ENABLED,
-    FUNC_STARTBACKPROC
 };
 
 INTFUNCDESC IntFuncTable[] = {
@@ -148,7 +147,7 @@ INTFUNCDESC IntFuncTable[] = {
     "SaveVariable", VAR_INTEGER, 2, "LoadVariable", VAR_INTEGER, 2, "SetControlTreshold", TVOID, 2, "LockControl",
     TVOID, 1, "TestRef", VAR_INTEGER, 1, "SetTimeScale", TVOID, 1, "CheckFunction", VAR_INTEGER, 0, "GetEngineVersion",
     VAR_INTEGER, 1, "GetDLCenabled", VAR_INTEGER, 0, "GetDLCCount", VAR_INTEGER, 1, "GetDLCData", VAR_INTEGER, 1,
-    "DLCStartOverlay", VAR_INTEGER, 0, "GetSteamEnabled", VAR_INTEGER, 1, "StartBackProcess", TVOID};
+    "DLCStartOverlay", VAR_INTEGER, 0, "GetSteamEnabled", VAR_INTEGER};
 
 /*
 char * FuncNameTable[]=
@@ -549,34 +548,6 @@ DATA *COMPILER::BC_CallIntFunction(uint32_t func_code, DATA *&pVResult, uint32_t
         }
         pVResult = pV;
         return pV;
-        break;
-
-    case FUNC_STARTBACKPROC:
-        pV = SStack.Pop();
-        if (!pV)
-        {
-            SetError(INVALID_FA);
-            break;
-        }
-        if (pV->GetType() == VAR_STRING)
-        {
-            pV->Get(pChar);
-            if (pChar == 0)
-            {
-                SetError("invalid string argument");
-                return 0;
-            }
-            if ((function_code = FuncTab.FindFunc(pChar)) == INVALID_FUNC_CODE)
-            {
-                SetError("invalid function");
-                return 0;
-            }
-            core.StartEvent(function_code);
-        }
-        else
-        {
-            SetError("unexpected thread parameter");
-        }
         break;
 
     case FUNC_GETENGINEVERSION:

--- a/src/libs/Common_h/core.h
+++ b/src/libs/Common_h/core.h
@@ -17,18 +17,6 @@
 
 #define ENGINE_SCRIPT_VERSION 54128
 
-template <typename T> struct tThrd
-{
-    typedef uint32_t (__thiscall T::*PMethod)();
-    static uint32_t WINAPI Function(PVOID pParam)
-    {
-        return (((tThrd *)pParam)->pThis->*((tThrd *)pParam)->pMethod)();
-    };
-    T *pThis;
-    PMethod pMethod;
-    HANDLE Handle;
-};
-
 class COMPILER;
 struct IFUNCINFO;
 class VDATA;
@@ -162,7 +150,7 @@ class CORE
 
     void *GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex = nullptr);
 
-    uint32_t Process();
+    uint32_t Process(const std::stop_token& stop_token);
     void StartEvent(uint32_t function_code);
     void StartThread();
     void ReleaseThread();
@@ -193,8 +181,7 @@ class CORE
 
   private:
     std::queue<uint32_t> thrQueue;
-    tThrd<CORE> MyThread;
-    HANDLE hEvent;
+    std::jthread MyThread;
 };
 // core instance
 inline CORE core;

--- a/src/libs/Common_h/core.h
+++ b/src/libs/Common_h/core.h
@@ -150,11 +150,6 @@ class CORE
 
     void *GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex = nullptr);
 
-    uint32_t Process(const std::stop_token& stop_token);
-    void StartEvent(uint32_t function_code);
-    void StartThread();
-    void ReleaseThread();
-
     // steam section
     CSteamStatsAchievements *g_SteamAchievements;
 
@@ -178,10 +173,6 @@ class CORE
     uint32_t getDLCCount();
     uint32_t getDLCDataByIndex(uint32_t iDLC);
     bool activateGameOverlayDLC(uint32_t nAppId);
-
-  private:
-    std::queue<uint32_t> thrQueue;
-    std::jthread MyThread;
 };
 // core instance
 inline CORE core;


### PR DESCRIPTION
Started replacing the threaded implementation with standard threading code, but it turns out threaded queue is not currently used.

If we intend to use the queue, I'll add proper locking and signaling. Otherwise we could just get rid of this code altogether.
