### PR TITLE
file_system: replace _FindFirstFile, _FindNextFile, _FindClose

### DIFF
--- a/src/apps/ENGINE/CMakeLists.txt
+++ b/src/apps/ENGINE/CMakeLists.txt
@@ -75,6 +75,7 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
     common_h
+    util
     
     animals
     animation

--- a/src/apps/ENGINE/compiler.cpp
+++ b/src/apps/ENGINE/compiler.cpp
@@ -24,8 +24,6 @@ extern uint32_t dwNumberScriptCommandsExecuted;
 COMPILER::COMPILER()
 {
     CompilerStage = CS_SYSTEM;
-    fio->_DeleteFile(COMPILER_LOG_FILENAME);
-    fio->_DeleteFile(COMPILER_ERRORLOG_FILENAME);
     LabelTable.SetStringDataSize(sizeof(uint32_t));
     LabelUpdateTable.SetStringDataSize(sizeof(DOUBLE_DWORD));
     ProgramDirectory = nullptr;
@@ -7164,22 +7162,12 @@ DATA *COMPILER::GetOperand(const char *pCodeBase, uint32_t &ip, S_TOKEN_TYPE *pT
 
 void COMPILER::FormatAllDialog(const char *directory_name)
 {
-    WIN32_FIND_DATA ffd;
+    const auto vPaths = fio->_GetPathsOrFilenamesByMask(directory_name, "*.c", true);
     char sFileName[MAX_PATH];
-    sprintf_s(sFileName, "%s\\*.c", directory_name);
-    const HANDLE fh = fio->_FindFirstFile(sFileName, &ffd);
-    if (fh != INVALID_HANDLE_VALUE)
+    for (std::string curPath : vPaths)
     {
-        std::string Utf8FileName = utf8::ConvertWideToUtf8(ffd.cFileName);
-        sprintf_s(sFileName, "%s\\%s", directory_name, Utf8FileName.c_str());
+        sprintf(sFileName, curPath.c_str());
         FormatDialog(sFileName);
-        while (fio->_FindNextFile(fh, &ffd))
-        {
-            Utf8FileName = utf8::ConvertWideToUtf8(ffd.cFileName);
-            sprintf_s(sFileName, "%s\\%s", directory_name, Utf8FileName.c_str());
-            FormatDialog(sFileName);
-        }
-        fio->_FindClose(fh);
     }
 }
 

--- a/src/apps/ENGINE/file_service.h
+++ b/src/apps/ENGINE/file_service.h
@@ -93,16 +93,20 @@ class FILE_SERVICE : public VFILE_SERVICE
     int _DeleteFile(const char *filename) override;
     bool _WriteFile(std::fstream &fileS, const void *s, std::streamsize count) override;
     bool _ReadFile(std::fstream &fileS, void *s, std::streamsize count) override;
-    HANDLE _FindFirstFile(const char *lpFileName, LPWIN32_FIND_DATA lpFindFileData) override;
-    BOOL _FindNextFile(HANDLE hFindFile, LPWIN32_FIND_DATA lpFindFileData) override;
-    BOOL _FindClose(HANDLE hFindFile) override;
+    bool _FileOrDirectoryExists(const char *p) override;
+    std::vector<std::string> _GetPathsOrFilenamesByMask(const char *sourcePath, const char *mask, bool getPaths,
+                                                  bool onlyDirs = false, bool onlyFiles = true) override;
+    std::vector<std::filesystem::path> _GetFsPathsByMask(const char *sourcePath, const char *mask, bool getPaths,
+                                                         bool onlyDirs = false, bool onlyFiles = true) override;
+    std::time_t _ToTimeT(std::filesystem::file_time_type tp) override;
+    std::filesystem::file_time_type _GetLastWriteTime(const char *filename) override;
     void _FlushFileBuffers(std::fstream &fileS) override;
     uint32_t _GetCurrentDirectory(uint32_t nBufferLength, char *lpBuffer) override;
     std::string _GetExecutableDirectory() override;
     std::uintmax_t _GetFileSize(const char *filename) override;
     BOOL _SetCurrentDirectory(const char *lpPathName) override;
     BOOL _CreateDirectory(const char *lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes) override;
-    BOOL _RemoveDirectory(const char *lpPathName) override;
+    std::uintmax_t _RemoveDirectory(const char *p) override;
     BOOL _SetFileAttributes(const char *lpFileName, uint32_t dwFileAttributes) override;
     BOOL LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize) override;
     // ini files section

--- a/src/libs/Common_h/vfile_service.h
+++ b/src/libs/Common_h/vfile_service.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <fstream>
 #include <string>
+#include <vector>
+#include <filesystem>
 
 class INIFILE;
 
@@ -21,16 +23,21 @@ class VFILE_SERVICE
     virtual int _DeleteFile(const char *filename) = 0;
     virtual bool _WriteFile(std::fstream &fileS, const void *s, std::streamsize count) = 0;
     virtual bool _ReadFile(std::fstream &fileS, void *s, std::streamsize count) = 0;
-    virtual HANDLE _FindFirstFile(const char *lpFileName, LPWIN32_FIND_DATA lpFindFileData) = 0;
-    virtual BOOL _FindNextFile(HANDLE hFindFile, LPWIN32_FIND_DATA lpFindFileData) = 0;
-    virtual BOOL _FindClose(HANDLE hFindFile) = 0;
+    virtual bool _FileOrDirectoryExists(const char *p) = 0;
+    virtual std::vector<std::string> _GetPathsOrFilenamesByMask(const char *sourcePath, const char *mask, bool getPaths,
+                                                                bool onlyDirs = false, bool onlyFiles = true) = 0;
+    virtual std::vector<std::filesystem::path> _GetFsPathsByMask(const char *sourcePath, const char *mask,
+                                                                 bool getPaths, bool onlyDirs = false,
+                                                                 bool onlyFiles = true) = 0;
+    virtual std::time_t _ToTimeT(std::filesystem::file_time_type tp) = 0;
+    virtual std::filesystem::file_time_type _GetLastWriteTime(const char *filename) = 0;
     virtual void _FlushFileBuffers(std::fstream &fileS) = 0;
     virtual uint32_t _GetCurrentDirectory(uint32_t nBufferLength, char *lpBuffer) = 0;
     virtual std::string _GetExecutableDirectory() = 0;
     virtual std::uintmax_t _GetFileSize(const char *filename) = 0;
     virtual BOOL _SetCurrentDirectory(const char *lpPathName) = 0;
     virtual BOOL _CreateDirectory(const char *lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes) = 0;
-    virtual BOOL _RemoveDirectory(const char *lpPathName) = 0;
+    virtual std::uintmax_t _RemoveDirectory(const char *p) = 0;
     virtual BOOL _SetFileAttributes(const char *lpFileName, uint32_t dwFileAttributes) = 0;
     virtual BOOL LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize = nullptr) = 0;
 

--- a/src/libs/Island/ISLAND.h
+++ b/src/libs/Island/ISLAND.h
@@ -111,9 +111,10 @@ class ISLAND : public ISLAND_BASE
     void AddLocationModel(entid_t eid, char *pIDStr, char *pStr);
 
     // debug
-    void DoZapSuperGenerator();
+    // dead code
+    /*void DoZapSuperGenerator();
     void DoZapSuperGeneratorInnerDecodeFiles(const char *sub_dir, const char *mask);
-    bool DoZapSuperGeneratorDecodeFile(const char *sname);
+    bool DoZapSuperGeneratorDecodeFile(const char *sname);*/
 
   public:
     ISLAND();

--- a/src/libs/Island/ZapSuperGenerator.cpp
+++ b/src/libs/Island/ZapSuperGenerator.cpp
@@ -2,7 +2,8 @@
 #include "tga.h"
 #include "vfile_service.h"
 
-bool ISLAND::DoZapSuperGeneratorDecodeFile(const char *sname)
+// dead code
+/*bool ISLAND::DoZapSuperGeneratorDecodeFile(const char *sname)
 {
     auto fileS = fio->_CreateFile(sname, std::ios::binary | std::ios::in);
     if (fileS.is_open())
@@ -66,4 +67,4 @@ void ISLAND::DoZapSuperGeneratorInnerDecodeFiles(const char *sub_dir, const char
 void ISLAND::DoZapSuperGenerator()
 {
     DoZapSuperGeneratorInnerDecodeFiles(nullptr, "*.tga");
-}
+}*/

--- a/src/libs/Mast/mast.cpp
+++ b/src/libs/Mast/mast.cpp
@@ -7,7 +7,7 @@
 #define DELTA_TIME(x) ((x)*0.001f)
 #define DELTA_TIME_ROTATE(x) ((x)*0.01f)
 
-const char *MAST_INI_FILE = "resource\\ini\\mast.ini";
+static const char *MAST_INI_FILE = "resource\\ini\\mast.ini";
 
 float MAST_MOVE_STEP = 0.2f;
 float MAST_FALL_STEP = .05f;
@@ -100,14 +100,10 @@ void MAST::Execute(uint32_t Delta_Time)
     {
         // ====================================================
         // If the ini-file has been changed, read the info from it
-        WIN32_FIND_DATA wfd;
-        auto *const h = fio->_FindFirstFile(MAST_INI_FILE, &wfd);
-        if (INVALID_HANDLE_VALUE != h)
+        if (fio->_FileOrDirectoryExists(MAST_INI_FILE))
         {
-            auto ft_new = wfd.ftLastWriteTime;
-            fio->_FindClose(h);
-
-            if (CompareFileTime(&ft_old, &ft_new) != 0)
+            auto ft_new = fio->_GetLastWriteTime(MAST_INI_FILE);
+            if (ft_old != ft_new)
             {
                 LoadIni();
             }
@@ -412,16 +408,15 @@ void MAST::LoadIni()
     // GUARD(MAST::LoadIni());
     char section[256];
 
-    WIN32_FIND_DATA wfd;
-    const HANDLE h = fio->_FindFirstFile(MAST_INI_FILE, &wfd);
-    if (INVALID_HANDLE_VALUE != h)
+    if (fio->_FileOrDirectoryExists(MAST_INI_FILE))
     {
-        ft_old = wfd.ftLastWriteTime;
-        fio->_FindClose(h);
+        ft_old = fio->_GetLastWriteTime(MAST_INI_FILE);
     }
     auto ini = fio->OpenIniFile(MAST_INI_FILE);
     if (!ini)
+    {
         throw std::exception("mast.ini file not found!");
+    }
 
     sprintf_s(section, "MAST");
 

--- a/src/libs/Mast/mast.h
+++ b/src/libs/Mast/mast.h
@@ -4,6 +4,8 @@
 #include "dx9render.h"
 #include "model.h"
 
+#include <filesystem>
+
 #define SR_MOVE 1
 #define SR_STOPROTATE 2
 #define SR_YROTATE 4
@@ -24,7 +26,7 @@ class MAST : public Entity
     bool bModel;
     entid_t model_id, oldmodel_id;
     entid_t ship_id;
-    FILETIME ft_old;
+    std::filesystem::file_time_type ft_old;
     NODE *m_pMastNode;
 
   public:

--- a/src/libs/Particles/Manager/particlemanager.cpp
+++ b/src/libs/Particles/Manager/particlemanager.cpp
@@ -694,18 +694,10 @@ void ParticleManager::OpenDefaultProject()
 
     SetProjectTexture("particles_list.tga");
 
-    HANDLE foundFile;
-    WIN32_FIND_DATA findData;
-    if ((foundFile = fio->_FindFirstFile("resource\\particles\\*.xps", &findData)) != INVALID_HANDLE_VALUE)
+    const auto vFilenames = fio->_GetPathsOrFilenamesByMask("resource\\particles", "*.xps", false);
+    for (std::string curName : vFilenames)
     {
-        do
-        {
-            // core.Trace("Cache system - %s", findData.cFileName);
-            std::string FileName = utf8::ConvertWideToUtf8(findData.cFileName);
-            pDataCache->CacheSystem(FileName.c_str());
-        } while (fio->_FindNextFile(foundFile, &findData) == TRUE);
-        if (foundFile != INVALID_HANDLE_VALUE)
-            fio->_FindClose(foundFile);
+        pDataCache->CacheSystem(curName.c_str());
     }
 
     CreateGeomCache();

--- a/src/libs/Rigging/Flag.cpp
+++ b/src/libs/Rigging/Flag.cpp
@@ -7,6 +7,8 @@
 #include "ship_base.h"
 #include "vfile_service.h"
 
+static const char *RIGGING_INI_FILE = "resource\\ini\\rigging.ini";
+
 FLAG::FLAG()
 {
     bUse = false;
@@ -84,14 +86,10 @@ void FLAG::Execute(uint32_t Delta_Time)
     {
         // ====================================================
         // If the ini-file has been changed, read the info from it
-        WIN32_FIND_DATA wfd;
-        auto *const h = fio->_FindFirstFile("resource\\ini\\rigging.ini", &wfd);
-        if (INVALID_HANDLE_VALUE != h)
+        if (fio->_FileOrDirectoryExists(RIGGING_INI_FILE))
         {
-            auto ft_new = wfd.ftLastWriteTime;
-            fio->_FindClose(h);
-
-            if (CompareFileTime(&ft_old, &ft_new) != 0)
+            auto ft_new = fio->_GetLastWriteTime(RIGGING_INI_FILE);
+            if (ft_old != ft_new)
             {
                 LoadIni();
             }
@@ -568,18 +566,17 @@ void FLAG::LoadIni()
     char section[256];
     char param[256];
 
-    WIN32_FIND_DATA wfd;
-    auto *const h = fio->_FindFirstFile("resource\\ini\\rigging.ini", &wfd);
-    if (INVALID_HANDLE_VALUE != h)
+    if (fio->_FileOrDirectoryExists(RIGGING_INI_FILE))
     {
-        ft_old = wfd.ftLastWriteTime;
-        fio->_FindClose(h);
+        ft_old = fio->_GetLastWriteTime(RIGGING_INI_FILE);
     }
     auto ini = fio->OpenIniFile("resource\\ini\\rigging.ini");
     if (!ini)
+    {
         throw std::exception("rigging.ini file not found!");
+    }
 
-    sprintf_s(section, "FLAGS");
+    sprintf(section, "FLAGS");
 
     auto texChange = false;
     int tmp;

--- a/src/libs/Rigging/Flag.h
+++ b/src/libs/Rigging/Flag.h
@@ -5,6 +5,8 @@
 #include "matrix.h"
 #include "model.h"
 
+#include <filesystem>
+
 #define FLAGLXVERTEX_FORMAT (D3DFVF_XYZ | D3DFVF_TEX1 | D3DFVF_TEXTUREFORMAT2)
 
 struct FLAGLXVERTEX
@@ -57,7 +59,7 @@ class FLAG : public Entity
     };
 
     WIND globalWind;
-    FILETIME ft_old;
+    std::filesystem::file_time_type ft_old;
 
   public:
     FLAG();

--- a/src/libs/Rigging/Vant.cpp
+++ b/src/libs/Rigging/Vant.cpp
@@ -6,6 +6,8 @@
 #include "ship_base.h"
 #include "vfile_service.h"
 
+static const char *RIGGING_INI_FILE = "resource\\ini\\rigging.ini";
+
 VANT_BASE::VANT_BASE()
 {
     bUse = false;
@@ -89,14 +91,10 @@ void VANT_BASE::Execute(uint32_t Delta_Time)
     {
         // ====================================================
         // If the ini-file has been changed, read the info from it
-        WIN32_FIND_DATA wfd;
-        auto *const h = fio->_FindFirstFile("resource\\ini\\rigging.ini", &wfd);
-        if (INVALID_HANDLE_VALUE != h)
+        if (fio->_FileOrDirectoryExists(RIGGING_INI_FILE))
         {
-            auto ft_new = wfd.ftLastWriteTime;
-            fio->_FindClose(h);
-
-            if (CompareFileTime(&ft_old, &ft_new) != 0)
+            auto ft_new = fio->_GetLastWriteTime(RIGGING_INI_FILE);
+            if (ft_old != ft_new)
             {
                 LoadIni();
             }
@@ -630,16 +628,15 @@ void VANT::LoadIni()
     char section[256];
     char param[256];
 
-    WIN32_FIND_DATA wfd;
-    const HANDLE h = fio->_FindFirstFile("resource\\ini\\rigging.ini", &wfd);
-    if (INVALID_HANDLE_VALUE != h)
+    if (fio->_FileOrDirectoryExists(RIGGING_INI_FILE))
     {
-        ft_old = wfd.ftLastWriteTime;
-        fio->_FindClose(h);
+        ft_old = fio->_GetLastWriteTime(RIGGING_INI_FILE);
     }
     auto ini = fio->OpenIniFile("resource\\ini\\rigging.ini");
     if (!ini)
+    {
         throw std::exception("rigging.ini file not found!");
+    }
 
     sprintf_s(section, "VANTS");
 
@@ -712,18 +709,17 @@ void VANTL::LoadIni()
     char section[256];
     char param[256];
 
-    WIN32_FIND_DATA wfd;
-    HANDLE h = fio->_FindFirstFile("resource\\ini\\rigging.ini", &wfd);
-    if (INVALID_HANDLE_VALUE != h)
+    if (fio->_FileOrDirectoryExists(RIGGING_INI_FILE))
     {
-        ft_old = wfd.ftLastWriteTime;
-        fio->_FindClose(h);
+        ft_old = fio->_GetLastWriteTime(RIGGING_INI_FILE);
     }
     auto ini = fio->OpenIniFile("resource\\ini\\rigging.ini");
     if (!ini)
+    {
         throw std::exception("rigging.ini file not found!");
+    }
 
-    sprintf_s(section, "VANTS_L");
+    sprintf(section, "VANTS_L");
 
     // texture name
     ini->ReadString(section, "TextureName", param, sizeof(param) - 1, "vant.tga");
@@ -794,18 +790,17 @@ void VANTZ::LoadIni()
     char section[256];
     char param[256];
 
-    WIN32_FIND_DATA wfd;
-    HANDLE h = fio->_FindFirstFile("resource\\ini\\rigging.ini", &wfd);
-    if (INVALID_HANDLE_VALUE != h)
+    if (fio->_FileOrDirectoryExists(RIGGING_INI_FILE))
     {
-        ft_old = wfd.ftLastWriteTime;
-        fio->_FindClose(h);
+        ft_old = fio->_GetLastWriteTime(RIGGING_INI_FILE);
     }
     auto ini = fio->OpenIniFile("resource\\ini\\rigging.ini");
     if (!ini)
+    {
         throw std::exception("rigging.ini file not found!");
+    }
 
-    sprintf_s(section, "VANTS_Z");
+    sprintf(section, "VANTS_Z");
 
     // texture name
     ini->ReadString(section, "TextureName", param, sizeof(param) - 1, "vant.tga");

--- a/src/libs/Rigging/Vant.h
+++ b/src/libs/Rigging/Vant.h
@@ -5,6 +5,8 @@
 #include "geos.h"
 #include "vmodule_api.h"
 
+#include <filesystem>
+
 class NODE;
 
 #define VANT_EDGE 5 // number of edges in the rope section
@@ -76,7 +78,7 @@ class VANT_BASE : public Entity
     float ZERO_CMP_VAL;    // Guy motion sampling step
     float MAXFALL_CMP_VAL; // the maximum change in the guy position at which the guy stops being displayed
     // -------------------------------------
-    FILETIME ft_old;
+    std::filesystem::file_time_type ft_old;
 
     bool bUse;
     bool bRunFirstTime;

--- a/src/libs/Rigging/sail.h
+++ b/src/libs/Rigging/sail.h
@@ -7,6 +7,8 @@
 #include "sail_base.h"
 #include "vmodule_api.h"
 
+#include <filesystem>
+
 class VDATA;
 
 struct SAILGROUP
@@ -77,7 +79,7 @@ class SAIL : public SAIL_BASE
     bool bUse;
     VDX9RENDER *RenderService;
     D3DMATERIAL9 mat;
-    FILETIME ft_old;
+    std::filesystem::file_time_type ft_old;
     long texl;
     long m_nEmptyGerbTex;
 

--- a/src/libs/SoundService/SoundService.cpp
+++ b/src/libs/SoundService/SoundService.cpp
@@ -981,20 +981,10 @@ void SoundService::LoadAliasFile(const char *_filename)
 
 void SoundService::InitAliases()
 {
-    std::string iniName = ALIAS_DIRECTORY;
-    iniName += "*.ini";
-
-    HANDLE foundFile;
-    WIN32_FIND_DATA findData;
-    if ((foundFile = fio->_FindFirstFile(iniName.c_str(), &findData)) != INVALID_HANDLE_VALUE)
+    const auto vFilenames = fio->_GetPathsOrFilenamesByMask(ALIAS_DIRECTORY, "*.ini", false);
+    for (std::string curName : vFilenames)
     {
-        do
-        {
-            std::string FileName = utf8::ConvertWideToUtf8(findData.cFileName);
-            LoadAliasFile(FileName.c_str());
-        } while (fio->_FindNextFile(foundFile, &findData) == TRUE);
-        if (foundFile != INVALID_HANDLE_VALUE)
-            fio->_FindClose(foundFile);
+        LoadAliasFile(curName.c_str());
     }
 }
 

--- a/src/libs/Teleport/teleport.cpp
+++ b/src/libs/Teleport/teleport.cpp
@@ -281,31 +281,25 @@ bool FINDFILESINTODIRECTORY::Init()
     {
         auto *const dirName = AttributesPointer->GetAttribute("dir");
         auto *const maskName = AttributesPointer->GetAttribute("mask");
-        char fullName[512];
-        fullName[0] = 0;
-        if (dirName)
-            sprintf_s(fullName, "%s\\", dirName);
+        const char *curMask;
         if (maskName)
-            strcat_s(fullName, maskName);
+        {
+            curMask = maskName;
+        }
         else
-            strcat_s(fullName, "*.*");
-        WIN32_FIND_DATA finddat;
-        auto *const hdl = fio->_FindFirstFile(fullName, &finddat);
+        {
+            curMask = "*.*";
+        }
+        auto file_idx = 0;
         auto *pA = AttributesPointer->CreateSubAClass(AttributesPointer, "filelist");
-        for (auto file_idx = 0; hdl != INVALID_HANDLE_VALUE; file_idx++)
+        const auto vFilenames = fio->_GetPathsOrFilenamesByMask(dirName, curMask, false);
+        for (std::string filename : vFilenames)
         {
             char sname[32];
-            sprintf_s(sname, "id%d", file_idx);
-            if (finddat.cFileName)
-            {
-                std::string FileName = utf8::ConvertWideToUtf8(finddat.cFileName);
-                pA->SetAttribute(sname, FileName.c_str());
-            }
-            if (!fio->_FindNextFile(hdl, &finddat))
-                break;
+            sprintf(sname, "id%d", file_idx);
+            pA->SetAttribute(sname, filename.c_str());
+            file_idx++;
         }
-        if (hdl != INVALID_HANDLE_VALUE)
-            fio->_FindClose(hdl);
         return true;
     }
     core.Trace("Attributes Pointer into class FINDFILESINTODIRECTORY = NULL");

--- a/src/libs/Xinterface/Nodes/xi_picture.cpp
+++ b/src/libs/Xinterface/Nodes/xi_picture.cpp
@@ -192,42 +192,20 @@ void CXI_PICTURE::SetNewPicture(bool video, char *sNewTexName)
 
 void CXI_PICTURE::SetNewPictureFromDir(char *dirName)
 {
-    int findQ;
-    WIN32_FIND_DATA wfd;
     char param[512];
+    sprintf(param, "resource\\textures\\%s", dirName);
 
-    sprintf_s(param, "resource\\textures\\%s\\*.tx", dirName);
-
-    auto *h = fio->_FindFirstFile(param, &wfd);
-    for (findQ = 0; h != INVALID_HANDLE_VALUE;)
+    const auto vFilenames = fio->_GetPathsOrFilenamesByMask(param, "*.tx", false);
+    if (!vFilenames.empty())
     {
-        findQ++;
-        if (!fio->_FindNextFile(h, &wfd))
-            break;
-    }
-    if (h != INVALID_HANDLE_VALUE)
-        fio->_FindClose(h);
-
-    if (findQ > 0)
-    {
-        findQ = rand() % findQ;
-        h = fio->_FindFirstFile(param, &wfd);
-        if (h != INVALID_HANDLE_VALUE)
-            for (; findQ > 0; findQ--)
-            {
-                if (!fio->_FindNextFile(h, &wfd))
-                    break;
-            }
-        if (h != INVALID_HANDLE_VALUE)
+        int findQ = rand() % vFilenames.size();
+        sprintf(param, "%s\\%s", dirName, vFilenames[findQ].c_str());
+        const int paramlen = strlen(param);
+        if (paramlen < sizeof(param) && paramlen >= 3)
         {
-            fio->_FindClose(h);
-            std::string FileName = utf8::ConvertWideToUtf8(wfd.cFileName);
-            sprintf(param, "%s\\%s", dirName, FileName.c_str());
-            const int paramlen = strlen(param);
-            if (paramlen < sizeof(param) && paramlen >= 3)
-                param[paramlen - 3] = 0;
-            SetNewPicture(false, param);
+            param[paramlen - 3] = 0;
         }
+        SetNewPicture(false, param);
     }
 }
 

--- a/src/libs/Xinterface/xinterface.h
+++ b/src/libs/Xinterface/xinterface.h
@@ -8,6 +8,8 @@
 #include "inode.h"
 #include "vmodule_api.h"
 
+#include <filesystem>
+
 class CXI_WINDOW;
 
 class XINTERFACE : public XINTERFACE_BASE
@@ -290,14 +292,14 @@ class XINTERFACE : public XINTERFACE_BASE
     {
         char *save_file_name;
         long file_size;
-        FILETIME time;
+        std::filesystem::file_time_type time;
 
         SAVE_FIND_DATA *next;
     };
 
     SAVE_FIND_DATA *m_pSaveFindRoot;
     void ReleaseSaveFindList();
-    void AddFindData(const char *sSaveFileName, long file_size, FILETIME create_time);
+    void AddFindData(std::filesystem::path filePath);
     void Sorting_FindData();
     SAVE_FIND_DATA *GetSaveDataByIndex(int n) const;
 

--- a/src/libs/Xinterface/xservice.cpp
+++ b/src/libs/Xinterface/xservice.cpp
@@ -227,32 +227,36 @@ void XSERVICE::LoadAllPicturesInfo()
     char param[255];
 
     // initialize ini file
-    WIN32_FIND_DATA wfd;
-    auto *const h = fio->_FindFirstFile(LISTS_INIFILE, &wfd);
-    if (INVALID_HANDLE_VALUE != h)
-        fio->_FindClose(h);
     auto ini = fio->OpenIniFile(LISTS_INIFILE);
     if (!ini)
+    {
         throw std::exception("ini file not found!");
+    }
 
     m_dwListQuantity = 0;
     m_dwImageQuantity = 0;
 
     // calculate lists quantity
     if (ini->GetSectionName(section, sizeof(section) - 1))
+    {
         do
+        {
             m_dwListQuantity++;
-        while (ini->GetSectionNameNext(section, sizeof(section) - 1));
+        } while (ini->GetSectionNameNext(section, sizeof(section) - 1));
+    }
     // create list pointers array
     if (m_dwListQuantity > 0)
     {
         m_pList = new IMAGELISTDESCR[m_dwListQuantity];
         if (m_pList == nullptr)
+        {
             throw std::exception("memory allocate error");
+        }
     }
 
     // fill lists
     if (ini->GetSectionName(section, sizeof(section) - 1))
+    {
         for (auto i = 0; true; i++)
         {
             m_pList[i].textureQuantity = 0;
@@ -314,6 +318,7 @@ void XSERVICE::LoadAllPicturesInfo()
             if (!ini->GetSectionNameNext(section, sizeof(section) - 1))
                 break;
         }
+    }
 }
 
 void XSERVICE::ReleaseAll()

--- a/src/libs/util/include/storm/string_compare.hpp
+++ b/src/libs/util/include/storm/string_compare.hpp
@@ -57,4 +57,97 @@ inline bool iLess(const Range1T &first, const Range2T &second)
     return std::lexicographical_compare(std::begin(first), std::end(first), std::begin(second), std::end(second), detail::is_iless{});
 }
 
+// The wildcmp function was taken from http://www.codeproject.com/KB/string/wildcmp.aspx; the
+// wildicmp (case insensitive wildcard comparison) was based on it.
+
+int wildcmp(const char *wild, const char *string)
+{
+    // Written by Jack Handy - jakkhandy@hotmail.com
+
+    const char *cp = NULL, *mp = NULL;
+
+    while ((*string) && (*wild != '*'))
+    {
+        if ((*wild != *string) && (*wild != '?'))
+        {
+            return 0;
+        }
+        wild++;
+        string++;
+    }
+
+    while (*string)
+    {
+        if (*wild == '*')
+        {
+            if (!*++wild)
+            {
+                return 1;
+            }
+            mp = wild;
+            cp = string + 1;
+        }
+        else if ((*wild == *string) || (*wild == '?'))
+        {
+            wild++;
+            string++;
+        }
+        else
+        {
+            wild = mp;
+            string = cp++;
+        }
+    }
+
+    while (*wild == '*')
+    {
+        wild++;
+    }
+    return !*wild;
+}
+
+int wildicmp(const char *wild, const char *string)
+{
+    const char *cp = nullptr, *mp = nullptr;
+
+    while ((*string) && (*wild != '*'))
+    {
+        if ((tolower(*wild) != tolower(*string)) && (*wild != '?'))
+        {
+            return 0;
+        }
+        wild++;
+        string++;
+    }
+
+    while (*string)
+    {
+        if (*wild == '*')
+        {
+            if (!*++wild)
+            {
+                return 1;
+            }
+            mp = wild;
+            cp = string + 1;
+        }
+        else if ((tolower(*wild) == tolower(*string)) || (*wild == '?'))
+        {
+            wild++;
+            string++;
+        }
+        else
+        {
+            wild = mp;
+            string = cp++;
+        }
+    }
+
+    while (*wild == '*')
+    {
+        wild++;
+    }
+    return !*wild;
+}
+
 } // namespace storm


### PR DESCRIPTION
- Replace _FindFirstFile, _FindNextFile, _FindClose with std::filesystem::directory_iterator, std::filesystem::exists and std::filesystem::last_write_time.
- Replace _RemoveDirectory with std::fs::remove_all.
- Replace FILETIME (and CompareFileTime) with std::filesystem::file_time_type when it was needed.
- Add wildcmp and wildicmp to string compare utils.