### PR TITLE
ini: fix reading ini files with LF endings

### DIFF
--- a/src/apps/ENGINE/fs.cpp
+++ b/src/apps/ENGINE/fs.cpp
@@ -11,7 +11,9 @@ path GetStashPath()
         wchar_t *str = nullptr;
         SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_SIMPLE_IDLIST, nullptr, &str);
         path = str;
-        path = path / L"My Games" / L"Sea Dogs";
+        const auto u8str = path.u8string();
+        const std::string toUtf8(u8str.begin(), u8str.end());
+        path = fs::path(toUtf8) / "My Games" / "Sea Dogs";
         CoTaskMemFree(str);
     }
     return path;

--- a/src/apps/ENGINE/ifs.cpp
+++ b/src/apps/ENGINE/ifs.cpp
@@ -432,27 +432,17 @@ void IFS::Format(char *file_data, long file_size)
         }
     }
 
-    for (n = 0; n < file_size; n++)
+    long offset = 0;
+    for (data_PTR = file_data; data_PTR < file_data + file_size; data_PTR += offset)
     {
-        if (n == 0)
-        {
-            data_PTR = file_data;
-        }
-        else
-        {
-            if (file_data[n] != 0)
-                continue;
-            if ((n + 1) >= file_size)
-                break; // end of file
-            if (file_data[n + 1] == 0)
-                continue; // separator zero
-            data_PTR = file_data + n + 1;
-        }
+        while (data_PTR < file_data + file_size && *data_PTR == '\0')
+            data_PTR++; // separator zero
 
-        // add new key object ------------------------------------------------------
-        // (file_data + n + 1) - start of the line
+        if (data_PTR >= file_data + file_size)
+            break; // end of file
 
-        long offset = 0;
+        // add new key object
+        offset = 0;
         for (; data_PTR[offset]; offset++)
         {
         }
@@ -545,7 +535,6 @@ void IFS::Format(char *file_data, long file_size)
                 node->SetName(&data_PTR[i]); // key without value
             break;
         }
-        n += offset;
     }
 }
 


### PR DESCRIPTION
I will show the error on the example of reading the file `loclighter.ini`
Option 1 CRLF:
```
; Loading Location lighter/r/n
loading = 1/r/n
; Enable automatic trace auto preparing data/r/n
```
End of the first pass of the loop before executing the code `n += offset;` we have:
n = 0 and offset = 25

After adding `n += offset;` and `n++` from the loop we got:
n = 26 and this indicates `/ n` (which became` / 0`).
It turns out that we do not fall into the condition: `if (file_data [n]! = 0)`

Option 2 LF:
```
; Loading Location lighter/n
loading = 1/n
; Enable automatic trace auto preparing data/n
```
End of the first pass through the loop before executing the code `n + = offset;` we have:
n = 0 and offset = 25

After adding `n += offset;` and `n++` from the loop we got:
n = 26 and this points to l (first character from 2nd line) and
and it turns out that we get into this condition: `if (file_data [n]! = 0)` and execute it until we get to the end of the line `/ 0`.

Thus, we always lose the second line from the ini file.

As a check, you can take a close look at the code before the changes:
```
    for (n = 0; n < file_size; n++)
    {
        if (n == 0)
        {
            data_PTR = file_data;
        }
        else
        {
            if (file_data[n] != 0)
                continue;
            if ((n + 1) >= file_size)
                break; // end of file
            if (file_data[n + 1] == 0)
                continue; // separator zero
            data_PTR = file_data + n + 1;
```
And the code after the changes:
```
    for (n = -1; n < file_size; n++)
    {
        if (n == -1)
        {
            data_PTR = file_data + n + 1; // is the same as data_PTR = file_data;
        }
        else
        {
            if (file_data[n] != 0)
                continue;
            if ((n + 1) >= file_size)
                break; // end of file
            if (file_data[n + 1] == 0)
                continue; // separator zero
            data_PTR = file_data + n + 1;
```
And then `data_PTR = file_data + n + 1;` could be used in 2 places.

Russian version:

Покажу ошибку на примере чтения файла `loclighter.ini`
Вариант 1 CRLF:
```
;Loading Location lighter/r/n
loading = 1/r/n
;Enable automatic trace auto preparing data/r/n
```
Конец первого прохода цикла до выполнения кода `n += offset;` мы имеем:
n = 0 и offset = 25

После сложения `n += offset;` и `n++` от цикла получаем:
n = 26 и это указывает на `/n` (который превратился в `/0`). 
Получается, что мы не попадаем в условие: `if (file_data[n] != 0)`

Вариант 2 LF:
```
;Loading Location lighter/n
loading = 1/n
;Enable automatic trace auto preparing data/n
```

Конец первого прохода цикла до выполнения кода `n += offset;`
n = 0 и offset = 25

После сложения `n += offset;` и `n++` от цикла получаем:
n = 26 и это указывает на l (первый символ из 2ой строки) и 
и получается, что мы попадаем в это условие: `if (file_data[n] != 0)` и выполняем его до тех пор, пока не встанем на конец строки `/0`.

Таким образом мы всегда теряем вторую строку из ini файла.

В качестве проверки можно внимательно посмотреть на код до изменени:
```
    for (n = 0; n < file_size; n++)
    {
        if (n == 0)
        {
            data_PTR = file_data;
        }
        else
        {
            if (file_data[n] != 0)
                continue;
            if ((n + 1) >= file_size)
                break; // end of file
            if (file_data[n + 1] == 0)
                continue; // separator zero
            data_PTR = file_data + n + 1;
```
И код после изменений:
```
    for (n = -1; n < file_size; n++)
    {
        if (n == -1)
        {
            data_PTR = file_data + n + 1; // is the same as data_PTR = file_data;
        }
        else
        {
            if (file_data[n] != 0)
                continue;
            if ((n + 1) >= file_size)
                break; // end of file
            if (file_data[n + 1] == 0)
                continue; // separator zero
            data_PTR = file_data + n + 1;
```
И тогда `data_PTR = file_data + n + 1;` можно было бы использовать в 2 местах. 