### PR TITLE
Replacement for last Windows-only file_system methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Setup third-party dependencies
 include(conan)
+set(ENV{CONAN_REVISIONS_ENABLED} 1)
+conan_add_remote(NAME bincrafters URL https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
 conan_cmake_run(CONANFILE conanfile.txt
     BASIC_SETUP CMAKE_TARGETS
     BUILD missing

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -2,6 +2,7 @@
 zlib/1.2.11
 spdlog/1.8.2
 sentry-native/0.4.8
+sdl2/2.0.14@bincrafters/stable
 
 # Development dependencies
 catch2/2.13.4

--- a/src/apps/ENGINE/CMakeLists.txt
+++ b/src/apps/ENGINE/CMakeLists.txt
@@ -123,6 +123,7 @@ target_link_libraries(${PROJECT_NAME}
 
     CONAN_PKG::zlib
     CONAN_PKG::sentry-native
+    CONAN_PKG::sdl2
     comctl32.lib
     dbghelp.lib
 )

--- a/src/apps/ENGINE/compiler.cpp
+++ b/src/apps/ENGINE/compiler.cpp
@@ -203,7 +203,7 @@ char *COMPILER::LoadFile(const char *file_name, uint32_t &file_size, bool bFullP
         std::string EngineDir = "storm-engine\\";
         if (strncmp(file_name, EngineDir.c_str(), EngineDir.length()) == 0)
         {
-            std::string ExePath = fio->_GetExecutableDirectory() + "\\resource\\shared\\";
+            std::string ExePath = fio->_GetExecutableDirectory() + "resource\\shared\\";
             strcpy_s(buffer, ExePath.c_str());
             strcat_s(buffer, file_name + EngineDir.length());
         }

--- a/src/apps/ENGINE/file_service.cpp
+++ b/src/apps/ENGINE/file_service.cpp
@@ -187,8 +187,7 @@ void FILE_SERVICE::_FlushFileBuffers(std::fstream &fileS)
 std::string FILE_SERVICE::_GetCurrentDirectory()
 {
     const auto curPath = std::filesystem::current_path().u8string();
-    std::string result(curPath.size(), '\0');
-    std::memcpy(result.data(), curPath.data(), curPath.size());
+    std::string result(curPath.begin(), curPath.end());
     return result;
 }
 

--- a/src/apps/ENGINE/file_service.cpp
+++ b/src/apps/ENGINE/file_service.cpp
@@ -6,6 +6,7 @@
 #include <exception>
 #include <storm/string_compare.hpp>
 #include <string>
+#include <SDL.h>
 
 #define COMMENT ';'
 #define SECTION_A '['
@@ -56,7 +57,7 @@ void FILE_SERVICE::_SetFilePointer(std::fstream &fileS, std::streamoff off, std:
     fileS.seekp(off, dir);
 }
 
-int FILE_SERVICE::_DeleteFile(const char *filename)
+bool FILE_SERVICE::_DeleteFile(const char *filename)
 {
     std::filesystem::path path = std::filesystem::u8path(filename);
     return std::filesystem::remove(path);
@@ -183,27 +184,15 @@ void FILE_SERVICE::_FlushFileBuffers(std::fstream &fileS)
     fileS.flush();
 }
 
-uint32_t FILE_SERVICE::_GetCurrentDirectory(uint32_t nBufferLength, char *lpBuffer)
+void FILE_SERVICE::_GetCurrentDirectory(char *buffer)
 {
-    wchar_t BufferW[MAX_PATH];
-    uint32_t Res = GetCurrentDirectory(nBufferLength, BufferW);
-    std::string CurrentDirectory = utf8::ConvertWideToUtf8(BufferW);
-    strcpy_s(lpBuffer, nBufferLength, CurrentDirectory.c_str());
-    return Res;
+    strcpy(buffer, std::filesystem::current_path().string().c_str());
 }
 
 std::string FILE_SERVICE::_GetExecutableDirectory()
 {
-    wchar_t BufferW[MAX_PATH];
-    uint32_t Res = GetModuleFileName(NULL, BufferW, MAX_PATH);
-    Assert(Res);
-    std::string ExePath = utf8::ConvertWideToUtf8(BufferW);
-    size_t i = ExePath.rfind('\\', ExePath.length());
-    if (i != std::string::npos)
-    {
-        return ExePath.substr(0, i);
-    }
-    return "";
+    std::string result(SDL_GetBasePath());
+    return result;
 }
 
 std::uintmax_t FILE_SERVICE::_GetFileSize(const char *filename)
@@ -212,28 +201,22 @@ std::uintmax_t FILE_SERVICE::_GetFileSize(const char *filename)
     return std::filesystem::file_size(path);
 }
 
-BOOL FILE_SERVICE::_SetCurrentDirectory(const char *lpPathName)
+void FILE_SERVICE::_SetCurrentDirectory(const char *pathName)
 {
-    std::wstring PathNameW = utf8::ConvertUtf8ToWide(lpPathName);
-    return SetCurrentDirectory(PathNameW.c_str());
+    std::filesystem::path path = std::filesystem::u8path(pathName);
+    std::filesystem::current_path(path);
 }
 
-BOOL FILE_SERVICE::_CreateDirectory(const char *lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes)
+bool FILE_SERVICE::_CreateDirectory(const char *pathName)
 {
-    std::wstring PathNameW = utf8::ConvertUtf8ToWide(lpPathName);
-    return CreateDirectory(PathNameW.c_str(), lpSecurityAttributes);
+    std::filesystem::path path = std::filesystem::u8path(pathName);
+    return std::filesystem::create_directory(path);
 }
 
-std::uintmax_t FILE_SERVICE::_RemoveDirectory(const char *p)
+std::uintmax_t FILE_SERVICE::_RemoveDirectory(const char *pathName)
 {
-    std::filesystem::path path = std::filesystem::u8path(p);
+    std::filesystem::path path = std::filesystem::u8path(pathName);
     return std::filesystem::remove_all(path);
-}
-
-BOOL FILE_SERVICE::_SetFileAttributes(const char *lpFileName, uint32_t dwFileAttributes)
-{
-    std::wstring FileNameW = utf8::ConvertUtf8ToWide(lpFileName);
-    return SetFileAttributes(FileNameW.c_str(), dwFileAttributes);
 }
 
 //------------------------------------------------------------------------------------------------
@@ -341,7 +324,7 @@ void FILE_SERVICE::Close()
     }
 }
 
-BOOL FILE_SERVICE::LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize)
+bool FILE_SERVICE::LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize)
 {
     if (ppBuffer == nullptr)
         return false;

--- a/src/apps/ENGINE/file_service.cpp
+++ b/src/apps/ENGINE/file_service.cpp
@@ -3,10 +3,10 @@
 #include "storm_assert.h"
 #include "utf8.h"
 
+#include <SDL.h>
 #include <exception>
 #include <storm/string_compare.hpp>
 #include <string>
-#include <SDL.h>
 
 #define COMMENT ';'
 #define SECTION_A '['
@@ -184,9 +184,12 @@ void FILE_SERVICE::_FlushFileBuffers(std::fstream &fileS)
     fileS.flush();
 }
 
-void FILE_SERVICE::_GetCurrentDirectory(char *buffer)
+std::string FILE_SERVICE::_GetCurrentDirectory()
 {
-    strcpy(buffer, std::filesystem::current_path().string().c_str());
+    const auto curPath = std::filesystem::current_path().u8string();
+    std::string result(curPath.size(), '\0');
+    std::memcpy(result.data(), curPath.data(), curPath.size());
+    return result;
 }
 
 std::string FILE_SERVICE::_GetExecutableDirectory()

--- a/src/apps/ENGINE/file_service.h
+++ b/src/apps/ENGINE/file_service.h
@@ -101,7 +101,7 @@ class FILE_SERVICE : public VFILE_SERVICE
     std::time_t _ToTimeT(std::filesystem::file_time_type tp) override;
     std::filesystem::file_time_type _GetLastWriteTime(const char *filename) override;
     void _FlushFileBuffers(std::fstream &fileS) override;
-    void _GetCurrentDirectory(char *buffer) override;
+    std::string _GetCurrentDirectory() override;
     std::string _GetExecutableDirectory() override;
     std::uintmax_t _GetFileSize(const char *filename) override;
     void _SetCurrentDirectory(const char *pathName) override;

--- a/src/apps/ENGINE/file_service.h
+++ b/src/apps/ENGINE/file_service.h
@@ -90,7 +90,7 @@ class FILE_SERVICE : public VFILE_SERVICE
     std::fstream _CreateFile(const char *filename, std::ios::openmode mode) override;
     void _CloseFile(std::fstream &fileS) override;
     void _SetFilePointer(std::fstream &fileS, std::streamoff off, std::ios::seekdir dir) override;
-    int _DeleteFile(const char *filename) override;
+    bool _DeleteFile(const char *filename) override;
     bool _WriteFile(std::fstream &fileS, const void *s, std::streamsize count) override;
     bool _ReadFile(std::fstream &fileS, void *s, std::streamsize count) override;
     bool _FileOrDirectoryExists(const char *p) override;
@@ -101,14 +101,13 @@ class FILE_SERVICE : public VFILE_SERVICE
     std::time_t _ToTimeT(std::filesystem::file_time_type tp) override;
     std::filesystem::file_time_type _GetLastWriteTime(const char *filename) override;
     void _FlushFileBuffers(std::fstream &fileS) override;
-    uint32_t _GetCurrentDirectory(uint32_t nBufferLength, char *lpBuffer) override;
+    void _GetCurrentDirectory(char *buffer) override;
     std::string _GetExecutableDirectory() override;
     std::uintmax_t _GetFileSize(const char *filename) override;
-    BOOL _SetCurrentDirectory(const char *lpPathName) override;
-    BOOL _CreateDirectory(const char *lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes) override;
-    std::uintmax_t _RemoveDirectory(const char *p) override;
-    BOOL _SetFileAttributes(const char *lpFileName, uint32_t dwFileAttributes) override;
-    BOOL LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize) override;
+    void _SetCurrentDirectory(const char *pathName) override;
+    bool _CreateDirectory(const char *pathName) override;
+    std::uintmax_t _RemoveDirectory(const char *pathName) override;
+    bool LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize) override;
     // ini files section
     void Close();
     std::unique_ptr<INIFILE> CreateIniFile(const char *file_name, bool fail_if_exist) override;

--- a/src/apps/ENGINE/ifs.cpp
+++ b/src/apps/ENGINE/ifs.cpp
@@ -545,9 +545,10 @@ bool IFS::FlushFile()
     char buff[2];
 
     if (bDataChanged == false)
+    {
         return true;
+    }
 
-    fs->_SetFileAttributes(FileName, FILE_ATTRIBUTE_NORMAL);
     fs->_DeleteFile(FileName);
     auto fileS = fio->_CreateFile(FileName, std::ios::binary | std::ios::out);
     if (!fileS.is_open())
@@ -646,7 +647,9 @@ bool IFS::FlushFile()
                 }
             }
             else
+            {
                 throw std::runtime_error("invalid key flag");
+            }
             node = node->GetRightNode();
         }
         section_node = section_node->GetRightNode();

--- a/src/apps/ENGINE/s_dbg_sourceview.cpp
+++ b/src/apps/ENGINE/s_dbg_sourceview.cpp
@@ -532,20 +532,16 @@ bool SOURCE_VIEW::OpenSourceFile(const char *_filename)
         CDebug.SaveRecentFileALine(SourceFileName, nActiveLine);
     }
 
-    char DirectoryName[MAX_PATH];
-    strcpy(DirectoryName, fio->_GetCurrentDirectory().c_str());
+    auto DirectoryName = fio->_GetCurrentDirectory();
 
-    strcat_s(DirectoryName, "\\");
-    strcat_s(DirectoryName, ProgramDirectory);
-    strcat_s(DirectoryName, "\\");
-    strcat_s(DirectoryName, _filename);
+    DirectoryName = DirectoryName + "\\" + ProgramDirectory + "\\" + _filename;
 
-    auto fileS = fio->_CreateFile(DirectoryName, std::ios::binary | std::ios::in);
+    auto fileS = fio->_CreateFile(DirectoryName.c_str(), std::ios::binary | std::ios::in);
     if (!fileS.is_open())
     {
         return false;
     }
-    const uint32_t nDataSize = fio->_GetFileSize(DirectoryName);
+    const uint32_t nDataSize = fio->_GetFileSize(DirectoryName.c_str());
 
     nTopLine = 0;
     delete pSourceFile;

--- a/src/apps/ENGINE/s_dbg_sourceview.cpp
+++ b/src/apps/ENGINE/s_dbg_sourceview.cpp
@@ -533,7 +533,7 @@ bool SOURCE_VIEW::OpenSourceFile(const char *_filename)
     }
 
     char DirectoryName[MAX_PATH];
-    fio->_GetCurrentDirectory(sizeof(DirectoryName), DirectoryName);
+    fio->_GetCurrentDirectory(DirectoryName);
 
     strcat_s(DirectoryName, "\\");
     strcat_s(DirectoryName, ProgramDirectory);

--- a/src/apps/ENGINE/s_dbg_sourceview.cpp
+++ b/src/apps/ENGINE/s_dbg_sourceview.cpp
@@ -533,7 +533,7 @@ bool SOURCE_VIEW::OpenSourceFile(const char *_filename)
     }
 
     char DirectoryName[MAX_PATH];
-    fio->_GetCurrentDirectory(DirectoryName);
+    strcpy(DirectoryName, fio->_GetCurrentDirectory().c_str());
 
     strcat_s(DirectoryName, "\\");
     strcat_s(DirectoryName, ProgramDirectory);

--- a/src/apps/ENGINE/s_debug.cpp
+++ b/src/apps/ENGINE/s_debug.cpp
@@ -556,8 +556,7 @@ uint32_t S_DEBUG::GetLineStatus(const char *_pFileName, uint32_t _linecode)
 
 bool S_DEBUG::BrowseFile(char *buffer, const char *filter)
 {
-    char DirectoryName[MAX_PATH];
-    strcpy(DirectoryName, fio->_GetCurrentDirectory().c_str());
+    auto DirectoryName = fio->_GetCurrentDirectory();
     wchar_t FilenameW[MAX_PATH];
     OPENFILENAME ofn;
     FilenameW[0] = 0;
@@ -574,14 +573,12 @@ bool S_DEBUG::BrowseFile(char *buffer, const char *filter)
     ofn.lpstrDefExt = FilterW.c_str();
     ofn.lpstrTitle = TEXT("Open script source file");
     const auto bRes = GetOpenFileName(&ofn);
-    fio->_SetCurrentDirectory(DirectoryName);
+    fio->_SetCurrentDirectory(DirectoryName.c_str());
     if (bRes)
     {
         std::string Filename = utf8::ConvertWideToUtf8(FilenameW);
-        strcat_s(DirectoryName, "\\");
-        strcat_s(DirectoryName, ProgramDirectory);
-        strcat_s(DirectoryName, "\\");
-        strcpy_s(buffer, MAX_PATH, Filename.c_str() + strlen(DirectoryName));
+        DirectoryName = DirectoryName + "\\" + ProgramDirectory + "\\";
+        strcpy_s(buffer, MAX_PATH, Filename.c_str() + strlen(DirectoryName.c_str()));
         //    strcpy_s(buffer,MAX_PATH, file_name + strlen(DirectoryName));
         // strcpy_s(buffer,file_name);
         return true;
@@ -591,8 +588,7 @@ bool S_DEBUG::BrowseFile(char *buffer, const char *filter)
 
 bool S_DEBUG::BrowseFileWP(char *buffer, const char *filter)
 {
-    char DirectoryName[MAX_PATH];
-    strcpy(DirectoryName, fio->_GetCurrentDirectory().c_str());
+    auto DirectoryName = fio->_GetCurrentDirectory();
     wchar_t FilenameW[MAX_PATH];
     OPENFILENAME ofn;
     FilenameW[0] = 0;
@@ -609,7 +605,7 @@ bool S_DEBUG::BrowseFileWP(char *buffer, const char *filter)
     ofn.lpstrDefExt = FilterW.c_str();
     ofn.lpstrTitle = TEXT("Open script source file");
     const auto bRes = GetOpenFileName(&ofn);
-    fio->_SetCurrentDirectory(DirectoryName);
+    fio->_SetCurrentDirectory(DirectoryName.c_str());
     if (bRes)
     {
         std::string Filename = utf8::ConvertWideToUtf8(FilenameW);

--- a/src/apps/ENGINE/s_debug.cpp
+++ b/src/apps/ENGINE/s_debug.cpp
@@ -557,7 +557,7 @@ uint32_t S_DEBUG::GetLineStatus(const char *_pFileName, uint32_t _linecode)
 bool S_DEBUG::BrowseFile(char *buffer, const char *filter)
 {
     char DirectoryName[MAX_PATH];
-    fio->_GetCurrentDirectory(DirectoryName);
+    strcpy(DirectoryName, fio->_GetCurrentDirectory().c_str());
     wchar_t FilenameW[MAX_PATH];
     OPENFILENAME ofn;
     FilenameW[0] = 0;
@@ -592,7 +592,7 @@ bool S_DEBUG::BrowseFile(char *buffer, const char *filter)
 bool S_DEBUG::BrowseFileWP(char *buffer, const char *filter)
 {
     char DirectoryName[MAX_PATH];
-    fio->_GetCurrentDirectory(DirectoryName);
+    strcpy(DirectoryName, fio->_GetCurrentDirectory().c_str());
     wchar_t FilenameW[MAX_PATH];
     OPENFILENAME ofn;
     FilenameW[0] = 0;

--- a/src/apps/ENGINE/s_debug.cpp
+++ b/src/apps/ENGINE/s_debug.cpp
@@ -557,7 +557,7 @@ uint32_t S_DEBUG::GetLineStatus(const char *_pFileName, uint32_t _linecode)
 bool S_DEBUG::BrowseFile(char *buffer, const char *filter)
 {
     char DirectoryName[MAX_PATH];
-    fio->_GetCurrentDirectory(sizeof(DirectoryName), DirectoryName);
+    fio->_GetCurrentDirectory(DirectoryName);
     wchar_t FilenameW[MAX_PATH];
     OPENFILENAME ofn;
     FilenameW[0] = 0;
@@ -592,7 +592,7 @@ bool S_DEBUG::BrowseFile(char *buffer, const char *filter)
 bool S_DEBUG::BrowseFileWP(char *buffer, const char *filter)
 {
     char DirectoryName[MAX_PATH];
-    fio->_GetCurrentDirectory(sizeof(DirectoryName), DirectoryName);
+    fio->_GetCurrentDirectory(DirectoryName);
     wchar_t FilenameW[MAX_PATH];
     OPENFILENAME ofn;
     FilenameW[0] = 0;

--- a/src/libs/Common_h/vfile_service.h
+++ b/src/libs/Common_h/vfile_service.h
@@ -32,7 +32,7 @@ class VFILE_SERVICE
     virtual std::time_t _ToTimeT(std::filesystem::file_time_type tp) = 0;
     virtual std::filesystem::file_time_type _GetLastWriteTime(const char *filename) = 0;
     virtual void _FlushFileBuffers(std::fstream &fileS) = 0;
-    virtual void _GetCurrentDirectory(char *buffer) = 0;
+    virtual std::string _GetCurrentDirectory() = 0;
     virtual std::string _GetExecutableDirectory() = 0;
     virtual std::uintmax_t _GetFileSize(const char *filename) = 0;
     virtual void _SetCurrentDirectory(const char *pathName) = 0;

--- a/src/libs/Common_h/vfile_service.h
+++ b/src/libs/Common_h/vfile_service.h
@@ -20,7 +20,7 @@ class VFILE_SERVICE
     virtual std::fstream _CreateFile(const char *filename, std::ios::openmode mode) = 0;
     virtual void _CloseFile(std::fstream &fileS) = 0;
     virtual void _SetFilePointer(std::fstream &fileS, std::streamoff off, std::ios::seekdir dir) = 0;
-    virtual int _DeleteFile(const char *filename) = 0;
+    virtual bool _DeleteFile(const char *filename) = 0;
     virtual bool _WriteFile(std::fstream &fileS, const void *s, std::streamsize count) = 0;
     virtual bool _ReadFile(std::fstream &fileS, void *s, std::streamsize count) = 0;
     virtual bool _FileOrDirectoryExists(const char *p) = 0;
@@ -32,14 +32,13 @@ class VFILE_SERVICE
     virtual std::time_t _ToTimeT(std::filesystem::file_time_type tp) = 0;
     virtual std::filesystem::file_time_type _GetLastWriteTime(const char *filename) = 0;
     virtual void _FlushFileBuffers(std::fstream &fileS) = 0;
-    virtual uint32_t _GetCurrentDirectory(uint32_t nBufferLength, char *lpBuffer) = 0;
+    virtual void _GetCurrentDirectory(char *buffer) = 0;
     virtual std::string _GetExecutableDirectory() = 0;
     virtual std::uintmax_t _GetFileSize(const char *filename) = 0;
-    virtual BOOL _SetCurrentDirectory(const char *lpPathName) = 0;
-    virtual BOOL _CreateDirectory(const char *lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes) = 0;
-    virtual std::uintmax_t _RemoveDirectory(const char *p) = 0;
-    virtual BOOL _SetFileAttributes(const char *lpFileName, uint32_t dwFileAttributes) = 0;
-    virtual BOOL LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize = nullptr) = 0;
+    virtual void _SetCurrentDirectory(const char *pathName) = 0;
+    virtual bool _CreateDirectory(const char *pathName) = 0;
+    virtual std::uintmax_t _RemoveDirectory(const char *pathName) = 0;
+    virtual bool LoadFile(const char *file_name, char **ppBuffer, uint32_t *dwSize = nullptr) = 0;
 
     // ini files section
     virtual std::unique_ptr<INIFILE> CreateIniFile(const char *file_name, bool fail_if_exist) = 0;

--- a/src/libs/Island/ISLAND.cpp
+++ b/src/libs/Island/ISLAND.cpp
@@ -442,7 +442,7 @@ void ISLAND::CreateDirectories(char *pDir)
 {
     char sCurDir[256], sTemp[256];
 
-    fio->_GetCurrentDirectory(sCurDir);
+    strcpy(sCurDir, fio->_GetCurrentDirectory().c_str());
     if (strlen(sCurDir) && sCurDir[strlen(sCurDir) - 1] != '\\')
     {
         strcat_s(sCurDir, "\\");

--- a/src/libs/Island/ISLAND.cpp
+++ b/src/libs/Island/ISLAND.cpp
@@ -438,38 +438,8 @@ void ISLAND::CalcBoxParameters(CVECTOR &_vBoxCenter, CVECTOR &_vBoxSize)
     _vBoxSize = CVECTOR(x2 - x1, 0.0f, z2 - z1);
 }
 
-void ISLAND::CreateDirectories(char *pDir)
-{
-    char sCurDir[256], sTemp[256];
-
-    strcpy(sCurDir, fio->_GetCurrentDirectory().c_str());
-    if (strlen(sCurDir) && sCurDir[strlen(sCurDir) - 1] != '\\')
-    {
-        strcat_s(sCurDir, "\\");
-    }
-
-    char *pLast, *pStr;
-
-    pLast = pStr = pDir;
-    while (true)
-    {
-        pStr = strchr(pStr, '\\');
-        if (!pStr)
-        {
-            break;
-        }
-        strncpy_s(sTemp, pLast, pStr - pLast);
-        sTemp[pStr - pLast] = '\0';
-        pLast = ++pStr;
-        strcat_s(sCurDir, sTemp);
-        strcat_s(sCurDir, "\\");
-        fio->_CreateDirectory(sCurDir);
-    }
-}
-
 bool ISLAND::CreateShadowMap(char *pDir, char *pName)
 {
-    const std::string sDir;
     auto *const pWeather =
         static_cast<WEATHER_BASE *>(EntityManager::GetEntityPointer(EntityManager::GetEntityId("Weather")));
     if (pWeather == nullptr)
@@ -478,12 +448,7 @@ bool ISLAND::CreateShadowMap(char *pDir, char *pName)
     }
 
     const fs::path path = fs::path() / "resource" / "foam" / pDir / AttributesPointer->GetAttribute("LightingPath");
-    // MessageBoxA(NULL, (LPCSTR)path.c_str(), "", MB_OK); //~!~
-    // sDir.Format("resource\\foam\\%s\\%s\\", pDir, AttributesPointer->GetAttribute("LightingPath")); sDir.CheckPath();
-    // sprintf_s(fname, "%s%s.tga", (const char*)sDir.c_str(), pName);
     const std::string fileName = path.string() + pName + ".tga";
-
-    CreateDirectories((char *)sDir.c_str());
 
     fShadowMapSize = 2.0f * Max(vRealBoxSize.x, vRealBoxSize.z) + 1024.0f;
     fShadowMapStep = fShadowMapSize / DMAP_SIZE;
@@ -589,18 +554,11 @@ void ISLAND::Blur8(uint8_t **pBuffer, uint32_t dwSize)
 bool ISLAND::CreateHeightMap(char *pDir, char *pName)
 {
     TGA_H tga_head;
-    std::string sDir;
     char str_tmp[256];
 
     fs::path path = fs::path() / "resource" / "foam" / pDir / pName;
-    // MessageBoxA(NULL, (LPCSTR)path.c_str(), "", MB_OK); //~!~
     std::string fileName = path.string() + ".tga";
     std::string iniName = path.string() + ".ini";
-    // sDir.Format("resource\\\\foam\\\\%s\\\\", pDir); sDir.CheckPath();
-    // sprintf_s(fname, "%s%s.tga", (const char*)sDir.c_str(), pName);
-    // sprintf_s(iname, "%s%s.ini", (const char*)sDir.c_str(), pName);
-
-    CreateDirectories((char *)sDir.c_str());
 
     // calc center and size
     CalcBoxParameters(vBoxCenter, vRealBoxSize);

--- a/src/libs/Island/ISLAND.cpp
+++ b/src/libs/Island/ISLAND.cpp
@@ -442,9 +442,11 @@ void ISLAND::CreateDirectories(char *pDir)
 {
     char sCurDir[256], sTemp[256];
 
-    fio->_GetCurrentDirectory(sizeof(sCurDir), sCurDir);
+    fio->_GetCurrentDirectory(sCurDir);
     if (strlen(sCurDir) && sCurDir[strlen(sCurDir) - 1] != '\\')
+    {
         strcat_s(sCurDir, "\\");
+    }
 
     char *pLast, *pStr;
 
@@ -453,13 +455,15 @@ void ISLAND::CreateDirectories(char *pDir)
     {
         pStr = strchr(pStr, '\\');
         if (!pStr)
+        {
             break;
+        }
         strncpy_s(sTemp, pLast, pStr - pLast);
         sTemp[pStr - pLast] = '\0';
         pLast = ++pStr;
         strcat_s(sCurDir, sTemp);
         strcat_s(sCurDir, "\\");
-        BOOL bOk = fio->_CreateDirectory(sCurDir, nullptr);
+        fio->_CreateDirectory(sCurDir);
     }
 }
 

--- a/src/libs/Island/ISLAND.h
+++ b/src/libs/Island/ISLAND.h
@@ -97,8 +97,6 @@ class ISLAND : public ISLAND_BASE
 
     void CalcBoxParameters(CVECTOR &vBoxCenter, CVECTOR &vBoxSize);
 
-    void CreateDirectories(char *pDir);
-
     void SetName(char *pIslandName)
     {
         sIslandName = pIslandName;

--- a/src/libs/Lighter/LGeometry.cpp
+++ b/src/libs/Lighter/LGeometry.cpp
@@ -447,7 +447,7 @@ bool LGeometry::Save()
 {
     // Save the current path
     char *oldPath = new char[4096];
-    fio->_GetCurrentDirectory(oldPath);
+    strcpy(oldPath, fio->_GetCurrentDirectory().c_str());
     char *dir = new char[4096];
     // Saving objects
     bool result = true;

--- a/src/libs/Lighter/LGeometry.cpp
+++ b/src/libs/Lighter/LGeometry.cpp
@@ -447,7 +447,7 @@ bool LGeometry::Save()
 {
     // Save the current path
     char *oldPath = new char[4096];
-    fio->_GetCurrentDirectory(4096, oldPath);
+    fio->_GetCurrentDirectory(oldPath);
     char *dir = new char[4096];
     // Saving objects
     bool result = true;
@@ -468,7 +468,7 @@ bool LGeometry::Save()
                 dir[p] = 0;
                 if (_access(dir, 0) == -1)
                 {
-                    if (!fio->_CreateDirectory(dir, nullptr))
+                    if (!fio->_CreateDirectory(dir))
                     {
                         isCont = true;
                         break;

--- a/src/libs/Lighter/LGeometry.cpp
+++ b/src/libs/Lighter/LGeometry.cpp
@@ -446,8 +446,7 @@ float LGeometry::Trace(const CVECTOR &src, const CVECTOR &dst)
 bool LGeometry::Save()
 {
     // Save the current path
-    char *oldPath = new char[4096];
-    strcpy(oldPath, fio->_GetCurrentDirectory().c_str());
+    auto oldPath = fio->_GetCurrentDirectory();
     char *dir = new char[4096];
     // Saving objects
     bool result = true;
@@ -458,7 +457,7 @@ bool LGeometry::Save()
         if (object[i].lBufSize <= 0)
             continue;
         // Create a path
-        fio->_SetCurrentDirectory(oldPath);
+        fio->_SetCurrentDirectory(oldPath.c_str());
         bool isCont = false;
         for (long c = 0, p = 0; true; c++, p++)
         {
@@ -518,8 +517,7 @@ bool LGeometry::Save()
             result &= (fwrite(buf, sv * sizeof(uint32_t), 1, fl) == 1);
         fclose(fl);
     }
-    fio->_SetCurrentDirectory(oldPath);
-    delete[] oldPath;
+    fio->_SetCurrentDirectory(oldPath.c_str());
     delete[] dir;
     delete[] buf;
     return result;

--- a/src/libs/Xinterface/Stringservice/strservice.cpp
+++ b/src/libs/Xinterface/Stringservice/strservice.cpp
@@ -1328,7 +1328,7 @@ uint32_t _InterfaceCreateFolder(VS_STACK *pS)
         pcCurPtr++;
     }
     // create self directory
-    const long nSuccess = fio->_CreateDirectory(sFolderName, nullptr);
+    const long nSuccess = fio->_CreateDirectory(sFolderName);
 
     pDat = (VDATA *)pS->Push();
     if (!pDat)

--- a/src/libs/Xinterface/xinterface.cpp
+++ b/src/libs/Xinterface/xinterface.cpp
@@ -1036,17 +1036,13 @@ uint64_t XINTERFACE::ProcessMessage(MESSAGE &message)
         }
         else
         {
-            std::filesystem::path p = std::filesystem::u8path(param);
-            const auto mask = p.filename().string();
-            const auto vFilenames =
-                fio->_GetPathsOrFilenamesByMask(p.remove_filename().string().c_str(), mask.c_str(), true, false, false);
-            if (vFilenames.empty())
+            if (!fio->_FileOrDirectoryExists(param))
             {
                 systTime = std::time(nullptr);
             }
             else
             {
-                systTime = fio->_ToTimeT(fio->_GetLastWriteTime(vFilenames[0].c_str()));
+                systTime = fio->_ToTimeT(fio->_GetLastWriteTime(param));
             }
         }
         const auto locTime = std::localtime(&systTime);

--- a/src/libs/Xinterface/xinterface.cpp
+++ b/src/libs/Xinterface/xinterface.cpp
@@ -2877,7 +2877,7 @@ char *XINTERFACE::SaveFileFind(long saveNum, char *buffer, size_t bufSize, long 
         char *sSavePath = AttributesPointer->GetAttribute("SavePath");
         if (sSavePath != nullptr)
         {
-            fio->_CreateDirectory(sSavePath, nullptr);
+            fio->_CreateDirectory(sSavePath);
         }
 
         // start save file finding
@@ -3421,7 +3421,7 @@ int XINTERFACE::LoadIsExist()
     char *sSavePath = AttributesPointer->GetAttribute("SavePath");
     if (sSavePath != nullptr)
     {
-        fio->_CreateDirectory(sSavePath, nullptr);
+        fio->_CreateDirectory(sSavePath);
     }
 
     bool bFindFile = false;
@@ -3468,7 +3468,7 @@ void XINTERFACE::PrecreateDirForFile(const char *pcFullFileName)
             break;
         }
     if (n > 0)
-        fio->_CreateDirectory(path, nullptr);
+        fio->_CreateDirectory(path);
 }
 
 // controls Container


### PR DESCRIPTION
Replace _CreateDirectory, _GetCurrentDirectory, _SetCurrentDirectory using std::filesystem analogs
Replace _GetExecutableDirectory with SDL_GetBasePath
