### PR TITLE
Change Windows-specific ENGINE timer to std::chrono.

### DIFF
--- a/src/apps/ENGINE/timer.h
+++ b/src/apps/ENGINE/timer.h
@@ -76,7 +76,7 @@ class TIMER
             return FixedDeltaValue;
         }
         return Delta_Time;
-    };
+    }
 
     uint32_t GetDeltaTime()
     {

--- a/src/apps/ENGINE/timer.h
+++ b/src/apps/ENGINE/timer.h
@@ -66,7 +66,8 @@ class TIMER
 
         if (Delta_Time == 0)
         {
-            Delta_Time = 1;
+            rDelta_Time = Delta_Time = 1;
+            fDeltaTime = 1.0f;
         }
 
         Previous = Current;


### PR DESCRIPTION
I've replaced the Windows-only API's with cross-platform code for the ENGINE timer only.
Compiled and tested locally, with no issues.
Performance seems exactly the same.