### PR TITLE
Removed unnecessary ENGINE timer rDelta_Time assignment

### DIFF
--- a/src/apps/ENGINE/timer.h
+++ b/src/apps/ENGINE/timer.h
@@ -48,7 +48,7 @@ class TIMER
         Delta_Time = (uint32_t)Duration(Current - Previous).count();
         if (Delta_Time > (uint32_t)kMaxDelta.count())
         {
-            rDelta_Time = Delta_Time = (uint32_t)kMaxDelta.count();
+            Delta_Time = (uint32_t)kMaxDelta.count();
         }
 
         rDelta_Time = Delta_Time;


### PR DESCRIPTION
A very minor change to stop rDetla_Time from being assigned twice to the same value.