### PR TITLE
Fix incorrect events

### DIFF
--- a/src/libs/Rigging/sail.cpp
+++ b/src/libs/Rigging/sail.cpp
@@ -1658,7 +1658,7 @@ float SAIL::Cannon_Trace(long iBallOwner, const CVECTOR &src, const CVECTOR &dst
             long charIdx = -1;
             if (pA != nullptr)
                 charIdx = pA->GetAttributeAsDword("index", -1);
-            core.Event(SHIP_SAIL_DAMAGE, "lfff", charIdx, damagePoint.x, damagePoint.y, damagePoint.z);
+            core.Event(SHIP_SAIL_DAMAGE, "lfffl", charIdx, damagePoint.x, damagePoint.y, damagePoint.z, iBallOwner);
         }
     }
 

--- a/src/libs/Ship/ship.cpp
+++ b/src/libs/Ship/ship.cpp
@@ -1677,7 +1677,7 @@ float SHIP::Cannon_Trace(long iBallOwner, const CVECTOR &vSrc, const CVECTOR &vD
             if (fRes <= 1.0f)
             {
                 const CVECTOR v1 = vSrc + fRes * (vDst - vSrc);
-                VDATA *pV = core.Event(SHIP_MAST_DAMAGE, "llffffaa", SHIP_MAST_TOUCH_BALL, pM->iMastNum, v1.x, v1.y,
+                VDATA *pV = core.Event(SHIP_MAST_DAMAGE, "llffffal", SHIP_MAST_TOUCH_BALL, pM->iMastNum, v1.x, v1.y,
                                        v1.z, pM->fDamage, GetACharacter(), iBallOwner);
                 pM->fDamage = Clamp(pV->GetFloat());
                 MastFall(pM);


### PR DESCRIPTION
Fixed incorrect events.
One of them, `SHIP_MAST_DAMAGE` was causing a crash because of an incorrect format string, `llffffaa`. iBallOwner is a long, therefore the format string should be `llffffal`.
The other one was causing errors in [this](https://github.com/storm-devs/sd-teho-public/blob/e7d161eb1d4da25a73a517ff6d8373d8acbb6609/program/sea_ai/AIShip.c#L2262) script line. Scripts request not only the hit character's index, but the offender's too.