### PR TITLE
Add target_version compatibility setting to engine.ini

### DIFF
--- a/src/apps/ENGINE/Core.cpp
+++ b/src/apps/ENGINE/Core.cpp
@@ -6,6 +6,50 @@
 #include "fs.h"
 #include <fstream>
 
+#include <storm/string_compare.hpp>
+
+namespace storm
+{
+
+namespace
+{
+
+ENGINE_VERSION getTargetEngineVersion(const std::string_view &version)
+{
+    using namespace std::string_view_literals;
+
+    if (iEquals(version, "sd"sv))
+    {
+        return ENGINE_VERSION::SEA_DOGS;
+    }
+    else if (iEquals(version, "potc"sv))
+    {
+        return ENGINE_VERSION::PIRATES_OF_THE_CARIBBEAN;
+    }
+    else if (iEquals(version, "ct"sv))
+    {
+        return ENGINE_VERSION::CARIBBEAN_TALES;
+    }
+    else if (iEquals(version, "caos"sv))
+    {
+        return ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS;
+    }
+    else if (iEquals(version, "teho"sv))
+    {
+        return ENGINE_VERSION::TO_EACH_HIS_OWN;
+    }
+    else if (iEquals(version, "latest"sv))
+    {
+        return ENGINE_VERSION::LATEST;
+    }
+
+    return ENGINE_VERSION::UNKNOWN;
+}
+
+} // namespace
+
+} // namespace storm
+
 uint32_t dwNumberScriptCommandsExecuted = 0;
 
 typedef struct
@@ -220,6 +264,8 @@ void CORE::ProcessEngineIniFile()
         core.Controls = new CONTROLS;
     }
 
+    loadCompatibilitySettings(*engine_ini);
+
     res = engine_ini->ReadString(nullptr, "run", String, sizeof(String), "");
     if (res)
     {
@@ -227,17 +273,21 @@ void CORE::ProcessEngineIniFile()
             throw std::runtime_error("fail to create program");
         if (!Compiler->Run())
             throw std::runtime_error("fail to run program");
-        // Script version test
-        long iScriptVersion = 0xFFFFFFFF;
-        auto *pVScriptVersion = static_cast<VDATA *>(core.GetScriptVariable("iScriptVersion"));
-        if (pVScriptVersion)
-            pVScriptVersion->Get(iScriptVersion);
 
-        if (iScriptVersion != ENGINE_SCRIPT_VERSION)
+        // Script version test
+        if (m_targetVersion >= storm::ENGINE_VERSION::LATEST)
         {
-            ShowCursor(true);
-            MessageBoxA(nullptr, "Wrong script version", "Error", MB_OK);
-            Compiler->ExitProgram();
+            long iScriptVersion = 0xFFFFFFFF;
+            auto *pVScriptVersion = static_cast<VDATA *>(core.GetScriptVariable("iScriptVersion"));
+            if (pVScriptVersion)
+                pVScriptVersion->Get(iScriptVersion);
+
+            if (iScriptVersion != ENGINE_SCRIPT_VERSION)
+            {
+                ShowCursor(true);
+                MessageBoxA(nullptr, "Wrong script version", "Error", MB_OK);
+                Compiler->ExitProgram();
+            }
         }
     }
 }
@@ -856,3 +906,19 @@ void CORE::Leave_CriticalSection()
 {
     LeaveCriticalSection(&lock);
 };
+
+void CORE::loadCompatibilitySettings(INIFILE &inifile)
+{
+    using namespace storm;
+
+    std::array<char, 128> strBuffer{};
+    inifile.ReadString("compatibility", "target_version", strBuffer.data(), strBuffer.size(), "latest");
+    const std::string_view target_engine_version = strBuffer.data();
+
+    m_targetVersion = getTargetEngineVersion(target_engine_version);
+    if (m_targetVersion == ENGINE_VERSION::UNKNOWN)
+    {
+        tracelog->warn("Unknown target version '{}' in engine compatibility settings", target_engine_version);
+        m_targetVersion = ENGINE_VERSION::LATEST;
+    }
+}

--- a/src/apps/ENGINE/Core.cpp
+++ b/src/apps/ENGINE/Core.cpp
@@ -30,7 +30,7 @@ ENGINE_VERSION getTargetEngineVersion(const std::string_view &version)
     {
         return ENGINE_VERSION::CARIBBEAN_TALES;
     }
-    else if (iEquals(version, "caos"sv))
+    else if (iEquals(version, "coas"sv))
     {
         return ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS;
     }

--- a/src/libs/Common_h/CMakeLists.txt
+++ b/src/libs/Common_h/CMakeLists.txt
@@ -2,9 +2,7 @@ project(common_h)
 
 find_package(DirectX REQUIRED)
 
-add_library(${PROJECT_NAME} INTERFACE)
-
-target_include_directories(${PROJECT_NAME} INTERFACE .)
+auto_setup_library(${PROJECT_NAME} DIRECTORY .)
 
 target_include_directories(${PROJECT_NAME}
     INTERFACE
@@ -17,78 +15,3 @@ target_link_libraries(${PROJECT_NAME}
     ${DirectX_D3DX9_LIBRARY}
     CONAN_PKG::spdlog
 )
-
-set(PROJECT_SOURCES
-    math3d/Color.h
-    math3d/Matrix.h
-    math3d/Plane.h
-    math3d/Quaternion.h
-    math3d/Sphere.h
-    math3d/Triangle.h
-    math3d/Vector.h
-    math3d/Vector4.h
-
-    particles/gmx_QSort.h
-    particles/iparticlemanager.h
-    particles/iparticlesservice.h
-    particles/iparticlesystem.h
-
-    Sd2_h/CannonTrace.h
-    Sd2_h/SaveLoad.h
-    Sd2_h/VAI_ObjBase.h
-
-    Animation.h
-    attributes.h
-    Character.h
-    collide.h
-    controls.h
-    core.h
-    Cvector.h
-    CVector4.h
-    defines.h
-    dtimer.h
-    dx9render.h
-    Entity.h
-    entity_state.h
-    EntityManager.h
-    filesystem.h
-    geometry.h
-    geos.h
-    inlines.h
-    Intel.h
-    Island_Base.h
-    math3D.h
-    Matrix.h
-    message.h
-    model.h
-    object.h
-    particles.h
-    PtcData.h
-    rands.h
-    s_import_func.h
-    safequeue.h
-    sail_base.h
-    script_libriary.h
-    sea_base.h
-    service.h
-    ship_base.h
-    ship_msg.h
-    ShipLights.h
-    storm_assert.h
-    stringService.h
-    strutils.h
-    tga.h
-    IVBufferManager.h
-    triangle.h
-    types3d.h
-    utf8.h
-    v_s_stack.h
-    vdata.h
-    vfile_service.h
-    VideoTexture.h
-    vmodule_api.h
-    vparticle_system.h
-    Weather_Base.h
-)
-
-add_custom_target(${PROJECT_NAME}_ SOURCES ${PROJECT_SOURCES})

--- a/src/libs/Common_h/core.h
+++ b/src/libs/Common_h/core.h
@@ -4,6 +4,7 @@
 // common includes
 #include "EntityManager.h"
 #include "controls.h"
+#include "engine_version.hpp"
 #include "message.h"
 #include "vdata.h"
 #include "vfile_service.h"
@@ -153,6 +154,11 @@ class CORE
     const char *EngineIniFileName();
 
     void *GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex = nullptr);
+
+  private:
+    void loadCompatibilitySettings(INIFILE &inifile);
+
+    storm::ENGINE_VERSION m_targetVersion = storm::ENGINE_VERSION::LATEST;
 };
 // core instance
 extern CORE core;

--- a/src/libs/Common_h/engine_version.hpp
+++ b/src/libs/Common_h/engine_version.hpp
@@ -6,10 +6,10 @@ namespace storm
 enum class ENGINE_VERSION
 {
     UNKNOWN,
-    SEA_DOGS, // 1.0 - Will likely never be supported
+    SEA_DOGS,                 // 1.0 - Will likely never be supported
     PIRATES_OF_THE_CARIBBEAN, // 2.0
-    CARIBBEAN_TALES,
-    CITY_OF_ABANDONED_SHIPS, // 2.8
+    CARIBBEAN_TALES,          // 2.5
+    CITY_OF_ABANDONED_SHIPS,  // 2.8
     TO_EACH_HIS_OWN,
     LATEST, // Current, modified version
 };

--- a/src/libs/Common_h/engine_version.hpp
+++ b/src/libs/Common_h/engine_version.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace storm
+{
+
+enum class ENGINE_VERSION
+{
+    UNKNOWN,
+    SEA_DOGS, // 1.0 - Will likely never be supported
+    PIRATES_OF_THE_CARIBBEAN, // 2.0
+    CARIBBEAN_TALES,
+    CITY_OF_ABANDONED_SHIPS, // 2.8
+    TO_EACH_HIS_OWN,
+    LATEST, // Current, modified version
+};
+
+constexpr bool operator<(const ENGINE_VERSION first, const ENGINE_VERSION second) noexcept
+{
+    return static_cast<int>(first) < static_cast<int>(second);
+}
+
+} // namespace storm

--- a/src/libs/util/include/storm/string_compare.hpp
+++ b/src/libs/util/include/storm/string_compare.hpp
@@ -57,7 +57,7 @@ template <typename Range1T, typename Range2T = Range1T> inline bool iLess(const 
 // The wildcmp function was taken from http://www.codeproject.com/KB/string/wildcmp.aspx; the
 // wildicmp (case insensitive wildcard comparison) was based on it.
 
-int wildcmp(const char *wild, const char *string)
+inline int wildcmp(const char *wild, const char *string)
 {
     // Written by Jack Handy - jakkhandy@hotmail.com
 
@@ -103,7 +103,7 @@ int wildcmp(const char *wild, const char *string)
     return !*wild;
 }
 
-int wildicmp(const char *wild, const char *string)
+inline int wildicmp(const char *wild, const char *string)
 {
     const char *cp = nullptr, *mp = nullptr;
 


### PR DESCRIPTION
Adds compatibility settings for targeting all older Storm Engine games. 

Currently does not do anything except disabling the script version check.
