### PR TITLE
Restore default behaviour for script function SendMessage

### DIFF
--- a/src/apps/ENGINE/internal_functions.cpp
+++ b/src/apps/ENGINE/internal_functions.cpp
@@ -1845,7 +1845,7 @@ DATA *COMPILER::BC_CallIntFunction(uint32_t func_code, DATA *&pVResult, uint32_t
 
         CreateMessage(&ms, s_off, 1);
 
-        uint64_t mresult = -1;
+        uint64_t mresult = 0;
         pE = EntityManager::GetEntityPointer(ent);
         if (pE)
         {


### PR DESCRIPTION
SendMessage's default behavior when first argument was not a valid entity was to return 0, according to [this](https://github.com/storm-devs/storm-engine/blob/76e8eaf9cde9ed95dc5b65e34e57a3613d387242/ENGINE/Sources/internal_functions.cpp#L1552) line. This was changed in thunderstorm. Some code in TEHO stopped functioning because of that, for example F2 interface wouldn't open on worldmap. While this is something that can and should be fixed in scripts, I'm pretty sure COAS relied on SendMessage returning 0 too, so this behavior should be reverted for compatibility reasons.