### PR TITLE
Fix crash caused by TEHO's composite masts

### DIFF
--- a/src/libs/Mast/mast.cpp
+++ b/src/libs/Mast/mast.cpp
@@ -272,6 +272,12 @@ void MAST::Mount(entid_t modelEI, entid_t shipEI, NODE *mastNodePointer)
                             core.Send_Message(flagEI, "lili", MSG_FLAG_TO_NEWHOST, modelEI, atoi(&gl.group_name[4]),
                                               model_id);
                     }
+                    else if (!strncmp(gl.group_name, "sflag", 5))
+                    {
+                        if (flagEI)
+                            core.Send_Message(flagEI, "lili", MSG_FLAG_TO_NEWHOST, modelEI, atoi(&gl.group_name[5]),
+                                              model_id);
+                    }
                 }
                 // also bring down the sails associated with this mast
                 if (sailEI)

--- a/src/libs/Ship/ShipLights.cpp
+++ b/src/libs/Ship/ShipLights.cpp
@@ -141,7 +141,7 @@ void ShipLights::AddDynamicLights(VAI_OBJBASE *pObject, const CVECTOR &vPos)
         return;
     }
 
-    ShipLight light;
+    ShipLight light = ShipLight{};
     light.bDynamicLight = true;
     light.pObject = pObject;
     light.vPos = vPos;

--- a/src/libs/Ship/ship.cpp
+++ b/src/libs/Ship/ship.cpp
@@ -943,7 +943,7 @@ void SHIP::MastFall(mast_t *pM)
                 {
                     entid_t ent;
                     ent = EntityManager::CreateEntity("mast");
-                    core.Send_Message(ent, "lpii", MSG_MAST_SETGEOMETRY, pM->pNode, GetId(), GetModelEID());
+                    core.Send_Message(ent, "lpii", MSG_MAST_SETGEOMETRY, pMast->pNode, GetId(), GetModelEID());
                     EntityManager::AddToLayer(ExecuteLayer, ent, iShipPriorityExecute + 1);
                     EntityManager::AddToLayer(RealizeLayer, ent, iShipPriorityRealize + 1);
                     pShipsLights->KillMast(this, pMast->pNode, false);


### PR DESCRIPTION
For reference, it used to be like [this](https://github.com/storm-devs/storm-engine/blob/76e8eaf9cde9ed95dc5b65e34e57a3613d387242/Ship/ship.cpp#L956), but was overwritten at some point. Was causing crashes in naval battles, because the same object (node) was destroyed twice.