### PR TITLE
Replace custom hash table with std::unordered_map

### DIFF
--- a/src/apps/ENGINE/Core.cpp
+++ b/src/apps/ENGINE/Core.cpp
@@ -886,7 +886,7 @@ const char *CORE::EngineIniFileName()
 
 void *CORE::GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex)
 {
-    VARINFO vi;
+    VarInfo vi;
 
     const auto dwVarIndex = Compiler->VarTab.FindVar(pVariableName);
     if (dwVarIndex == INVALID_VAR_CODE || !Compiler->VarTab.GetVar(vi, dwVarIndex))
@@ -895,7 +895,7 @@ void *CORE::GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex)
     if (pdwVarIndex)
         *pdwVarIndex = dwVarIndex;
 
-    return vi.pDClass;
+    return vi.value.get();
 }
 
 void CORE::Start_CriticalSection()

--- a/src/apps/ENGINE/Core.cpp
+++ b/src/apps/ENGINE/Core.cpp
@@ -886,16 +886,24 @@ const char *CORE::EngineIniFileName()
 
 void *CORE::GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex)
 {
-    VarInfo vi;
+    const VarInfo *real_var;
 
     const auto dwVarIndex = Compiler->VarTab.FindVar(pVariableName);
-    if (dwVarIndex == INVALID_VAR_CODE || !Compiler->VarTab.GetVar(vi, dwVarIndex))
+    if (dwVarIndex == INVALID_VAR_CODE)
+    {
         return nullptr;
+    }
+
+    real_var = Compiler->VarTab.GetVar(dwVarIndex);
+    if (real_var == nullptr)
+    {
+        return nullptr;
+    }
 
     if (pdwVarIndex)
         *pdwVarIndex = dwVarIndex;
 
-    return vi.value.get();
+    return real_var->value.get();
 }
 
 void CORE::Start_CriticalSection()

--- a/src/apps/ENGINE/compiler.cpp
+++ b/src/apps/ENGINE/compiler.cpp
@@ -6330,7 +6330,10 @@ bool COMPILER::ReadVariable(char *name, /* DWORD code,*/ bool bDim, uint32_t a_i
                 // SetError("load size mismatch");
                 // return false;
                 real_var->value->SetElementsNum(nElementsNum);
-                VarTab.SetElementsNum(var_code, nElementsNum);
+                if (!VarTab.SetElementsNum(var_code, nElementsNum))
+                {
+                    core.Trace("Unable to set elements num for %s", real_var->name.c_str());
+                }
             }
     }
     else

--- a/src/apps/ENGINE/compiler.cpp
+++ b/src/apps/ENGINE/compiler.cpp
@@ -710,7 +710,10 @@ VDATA *COMPILER::ProcessEvent(const char *event_name)
         {
             if (n < ei.elements)
             {
-                FuncTab.AddTime(ei.pFuncInfo[n].func_code, nTicks);
+                if (!FuncTab.AddTime(ei.pFuncInfo[n].func_code, nTicks))
+                {
+                    core.Trace("Invalid func_code = %u for AddTime", ei.pFuncInfo[n].func_code);
+                }
             }
         }
 
@@ -3783,12 +3786,22 @@ bool COMPILER::BC_CallFunction(uint32_t func_code, uint32_t &ip, DATA *&pVResult
     if (call_fi.segment_id == INTERNAL_SEGMENT_ID)
     {
         if (bRuntimeLog)
-            FuncTab.AddCall(func_code);
+        {
+            if (!FuncTab.AddCall(func_code))
+            {
+                core.Trace("Invalid func_code = %u for AddCall", func_code);
+            }
+        }
+
         // BC_CallIntFunction(func_code,pVResult,arguments);
         RDTSC_B(nTicks);
         BC_CallIntFunction(func_code, pVResult, arguments);
         RDTSC_E(nTicks);
-        FuncTab.AddTime(func_code, nTicks);
+
+        if (!FuncTab.AddTime(func_code, nTicks))
+        {
+            core.Trace("Invalid func_code = %u for AddTime", func_code);
+        }
     }
     else if (call_fi.segment_id == IMPORTED_SEGMENT_ID)
     {
@@ -3803,7 +3816,10 @@ bool COMPILER::BC_CallFunction(uint32_t func_code, uint32_t &ip, DATA *&pVResult
             }
         }
         RDTSC_E(nTicks);
-        FuncTab.AddTime(func_code, nTicks);
+        if (!FuncTab.AddTime(func_code, nTicks))
+        {
+            core.Trace("Invalid func_code = %u for AddTime", func_code);
+        }
     }
     else
     {
@@ -3812,7 +3828,10 @@ bool COMPILER::BC_CallFunction(uint32_t func_code, uint32_t &ip, DATA *&pVResult
         RDTSC_B(nTicks);
         BC_Execute(func_code, pVResult);
         RDTSC_E(nTicks);
-        FuncTab.AddTime(func_code, nTicks);
+        if (!FuncTab.AddTime(func_code, nTicks))
+        {
+            core.Trace("Invalid func_code = %u for AddTime", func_code);
+        }
         core.Leave_CriticalSection();
     }
     if (nDebugEnterMode == TMODE_MAKESTEP)
@@ -3904,7 +3923,12 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
     CompilerStage = CS_RUNTIME;
 
     if (bRuntimeLog)
-        FuncTab.AddCall(function_code);
+    {
+        if (!FuncTab.AddCall(function_code))
+        {
+            core.Trace("Invalid function_code = %u for AddCall", function_code);
+        }
+    }
 
     bDebugWaitForThisFunc = false;
 

--- a/src/apps/ENGINE/compiler.cpp
+++ b/src/apps/ENGINE/compiler.cpp
@@ -1198,7 +1198,8 @@ bool COMPILER::InitInternalFunctions()
             func_code = FuncTab.FindFunc(fi.name);
             FuncTab.GetFunc(fi, func_code);
             // SetError("Duplicate function name: %s",fi.name);
-            SetError("Function [%s] already declared in: %s line %d", fi.name.c_str(), fi.decl_file_name.c_str(), fi.decl_line);
+            SetError("Function [%s] already declared in: %s line %d", fi.name.c_str(), fi.decl_file_name.c_str(),
+                     fi.decl_line);
             return false;
         }
     }
@@ -1534,8 +1535,8 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                             func_code = FuncTab.FindFunc(fi.name);
                             FuncTab.GetFunc(fi, func_code);
                             // SetError("Duplicate function name: %s",fi.name);
-                            SetError("Function [%s] already declared in: %s line %d", fi.name.c_str(), fi.decl_file_name.c_str(),
-                                     fi.decl_line);
+                            SetError("Function [%s] already declared in: %s line %d", fi.name.c_str(),
+                                     fi.decl_file_name.c_str(), fi.decl_line);
 
                             return false;
                         }
@@ -3012,7 +3013,8 @@ bool COMPILER::CompileBlock(SEGMENT_DESC &Segment, bool &bFunctionBlock, uint32_
                         // skip imported funcs checking for now
                         break;
                     default:
-                        SetError("function %s(args:%d) doesnt accept %d arguments", fi.name.c_str(), fi.arguments, func_args);
+                        SetError("function %s(args:%d) doesnt accept %d arguments", fi.name.c_str(), fi.arguments,
+                                 func_args);
                         return false;
                     }
 

--- a/src/apps/ENGINE/compiler.cpp
+++ b/src/apps/ENGINE/compiler.cpp
@@ -1215,7 +1215,7 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
     char *pApend_file;
     char *pSegmentSource;
     FUNCINFO fi;
-    VARINFO vi;
+    VarInfo vi;
     LVARINFO lvi;
     CLASSINFO ci;
     CLASSINFO cci;
@@ -1558,7 +1558,6 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                         vi.segment_id = Segment.id;
                         vi.elements = 1;
                         vi.type = Token_type;
-                        vi.bArray = false;
                         Token.Get();
                         if (Token.GetType() == SQUARE_OPEN_BRACKET)
                         {
@@ -1575,27 +1574,26 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                     }
                                     else
                                     {
-                                        SetError("Invalid array (%s) size", vi.name);
+                                        SetError("Invalid array (%s) size", vi.name.c_str());
                                         return false;
                                     }
                                 }
                                 else
                                 {
-                                    SetError("Invalid array (%s) size", vi.name);
+                                    SetError("Invalid array (%s) size", vi.name.c_str());
                                     return false;
                                 }
                             }
                             else
                                 lvalue = static_cast<long>(atoll(Token.GetData()));
                             vi.elements = lvalue;
-                            vi.bArray = true;
                             Token.Get(); // SQUARE_CLOSE_BRACKET
                             Token.Get();
                         }
                         var_code = VarTab.AddVar(vi);
                         if (var_code == INVALID_VAR_CODE)
                         {
-                            SetError("Duplicate variable name: %s", vi.name);
+                            SetError("Duplicate variable name: %s", vi.name.c_str());
                             return false;
                         }
                         VarTab.GetVarX(vi, var_code);
@@ -1608,7 +1606,7 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                 // array
                                 if (SkipAuxiliaryTokens() != BLOCK_IN)
                                 {
-                                    SetError("Invalid array '%s' initialization", vi.name);
+                                    SetError("Invalid array '%s' initialization", vi.name.c_str());
                                     return false;
                                 }
                                 uint32_t aindex;
@@ -1635,51 +1633,51 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                     case TRUE_CONST:
                                         if (vi.type != VAR_INTEGER)
                                         {
-                                            SetError("Invalid array '%s' initialization parameter", vi.name);
+                                            SetError("Invalid array '%s' initialization parameter", vi.name.c_str());
                                             return false;
                                         }
-                                        vi.pDClass->Set(static_cast<long>(1));
+                                        vi.value->Set(static_cast<long>(1));
                                         break;
                                     case FALSE_CONST:
                                         if (vi.type != VAR_INTEGER)
                                         {
-                                            SetError("Invalid array '%s' initialization parameter", vi.name);
+                                            SetError("Invalid array '%s' initialization parameter", vi.name.c_str());
                                             return false;
                                         }
-                                        vi.pDClass->Set(static_cast<long>(0));
+                                        vi.value->Set(static_cast<long>(0));
                                         break;
 
                                     case NUMBER:
                                         if (vi.type != VAR_INTEGER)
                                         {
-                                            SetError("Invalid array '%s' initialization parameter", vi.name);
+                                            SetError("Invalid array '%s' initialization parameter", vi.name.c_str());
                                             return false;
                                         }
                                         if (bNeg)
-                                            vi.pDClass->Set(-atol(Token.GetData()), aindex);
+                                            vi.value->Set(-atol(Token.GetData()), aindex);
                                         else
-                                            vi.pDClass->Set(static_cast<long>(atoll(Token.GetData())));
+                                            vi.value->Set(static_cast<long>(atoll(Token.GetData())));
                                         aindex++;
                                         break;
                                     case FLOAT_NUMBER:
                                         if (vi.type != VAR_FLOAT)
                                         {
-                                            SetError("Invalid array '%s' initialization parameter", vi.name);
+                                            SetError("Invalid array '%s' initialization parameter", vi.name.c_str());
                                             return false;
                                         }
                                         if (bNeg)
-                                            vi.pDClass->Set(-static_cast<float>(atof(Token.GetData())), aindex);
+                                            vi.value->Set(-static_cast<float>(atof(Token.GetData())), aindex);
                                         else
-                                            vi.pDClass->Set(static_cast<float>(atof(Token.GetData())), aindex);
+                                            vi.value->Set(static_cast<float>(atof(Token.GetData())), aindex);
                                         aindex++;
                                         break;
                                     case STRING:
                                         if (vi.type != VAR_STRING)
                                         {
-                                            SetError("Invalid array '%s' initialization parameter", vi.name);
+                                            SetError("Invalid array '%s' initialization parameter", vi.name.c_str());
                                             return false;
                                         }
-                                        vi.pDClass->Set(Token.GetData(), aindex);
+                                        vi.value->Set(Token.GetData(), aindex);
                                         aindex++;
                                         break;
                                     case UNKNOWN:
@@ -1693,7 +1691,7 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                         break;
                                     if (Token.GetType() != COMMA)
                                     {
-                                        SetError("Invalid array '%s' initialization parameters list", vi.name);
+                                        SetError("Invalid array '%s' initialization parameters list", vi.name.c_str());
                                         return false;
                                     }
                                     SkipAuxiliaryTokens();
@@ -1716,33 +1714,33 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                 case TRUE_CONST:
                                     if (vi.type != VAR_INTEGER)
                                         break;
-                                    vi.pDClass->Set(static_cast<long>(1));
+                                    vi.value->Set(static_cast<long>(1));
                                     break;
                                 case FALSE_CONST:
                                     if (vi.type != VAR_INTEGER)
                                         break;
-                                    vi.pDClass->Set(static_cast<long>(0));
+                                    vi.value->Set(static_cast<long>(0));
                                     break;
                                 case NUMBER:
                                     if (vi.type != VAR_INTEGER)
                                         break;
                                     if (bNeg)
-                                        vi.pDClass->Set(-atol(Token.GetData()));
+                                        vi.value->Set(-atol(Token.GetData()));
                                     else
-                                        vi.pDClass->Set(static_cast<long>(atoll(Token.GetData())));
+                                        vi.value->Set(static_cast<long>(atoll(Token.GetData())));
                                     break;
                                 case FLOAT_NUMBER:
                                     if (vi.type != VAR_FLOAT)
                                         break;
                                     if (bNeg)
-                                        vi.pDClass->Set(-static_cast<float>(atof(Token.GetData())));
+                                        vi.value->Set(-static_cast<float>(atof(Token.GetData())));
                                     else
-                                        vi.pDClass->Set(static_cast<float>(atof(Token.GetData())));
+                                        vi.value->Set(static_cast<float>(atof(Token.GetData())));
                                     break;
                                 case STRING:
                                     if (vi.type != VAR_STRING)
                                         break;
-                                    vi.pDClass->Set(Token.GetData());
+                                    vi.value->Set(Token.GetData());
                                     break;
                                 case UNKNOWN:
 
@@ -2206,7 +2204,7 @@ bool COMPILER::CompileBlock(SEGMENT_DESC &Segment, bool &bFunctionBlock, uint32_
     DEFINFO di;
     uint32_t dwRCode;
 
-    VARINFO vi;
+    VarInfo vi;
     LVARINFO lvi;
 
     jump_offset = 0xffbadbad;
@@ -3867,7 +3865,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
     long nLeftOperandIndex;
     S_TOKEN_TYPE Token_type;
     FUNCINFO fi;
-    VARINFO vi;
+    VarInfo vi;
     DATA *pV;
     DATA *pVResult;
     //    DATA   ExpressionResult;    // while compile expression not ready, each function have its own register
@@ -4091,7 +4089,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                             SetError("Global variable not found");
                             return false;
                         }
-                        pV = vi.pDClass;
+                        pV = vi.value.get();
                     }
                     else
                     {
@@ -4122,7 +4120,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                         SetError("Global variable not found");
                         return false;
                     }
-                    pV = vi.pDClass;
+                    pV = vi.value.get();
                 }
                 else
                 {
@@ -4161,7 +4159,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                             SetError("Global variable not found");
                             return false;
                         }
-                        pV = vi.pDClass;
+                        pV = vi.value.get();
                     }
                     else
                     {
@@ -4191,7 +4189,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                         SetError("Global variable not found");
                         return false;
                     }
-                    pV = vi.pDClass;
+                    pV = vi.value.get();
                 }
                 else
                 {
@@ -4229,7 +4227,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                             SetError("Global variable not found");
                             return false;
                         }
-                        pV = vi.pDClass;
+                        pV = vi.value.get();
                     }
                     else
                     {
@@ -4262,7 +4260,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                         SetError("Global variable not found");
                         return false;
                     }
-                    pVV = vi.pDClass;
+                    pVV = vi.value.get();
                 }
                 else
                 {
@@ -4288,7 +4286,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                         SetError("Global variable not found");
                         return false;
                     }
-                    pV = vi.pDClass;
+                    pV = vi.value.get();
                 }
                 else
                 {
@@ -4321,7 +4319,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     return false;
                 }
-                pVV = vi.pDClass;
+                pVV = vi.value.get();
             }
             else
             {
@@ -4430,7 +4428,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     return false;
                 }
-                pVV = vi.pDClass;
+                pVV = vi.value.get();
             }
             else
             {
@@ -4573,7 +4571,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     return false;
                 }
-                pV = vi.pDClass;
+                pV = vi.value.get();
             }
             else
             {
@@ -4659,7 +4657,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     return false;
                 }
-                pV = vi.pDClass;
+                pV = vi.value.get();
             }
             else
             {
@@ -4696,7 +4694,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     return false;
                 }
-                pV = vi.pDClass;
+                pV = vi.value.get();
             }
             else
             {
@@ -5117,13 +5115,13 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     return false;
                 }
-                pVDst = vi.pDClass;
+                pVDst = vi.value.get();
                 // if(bUseIndex) pVDst = pVDst->GetArrayElement(dwBXIndex);
                 if (!pVDst)
                     return false;
                 if (pVDst->GetType() != VAR_REFERENCE)
                 {
-                    SetError("'%s' isnt reference", vi.name);
+                    SetError("'%s' isnt reference", vi.name.c_str());
                     return false;
                 }
                 break;
@@ -5139,7 +5137,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     return false;
                 if (pVDst->GetType() != VAR_REFERENCE)
                 {
-                    SetError("'%s' isnt reference", vi.name);
+                    SetError("'%s' isnt reference", vi.name.c_str());
                     return false;
                 }
                 break;
@@ -5163,7 +5161,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     return false;
                 }
-                pVSrc = vi.pDClass;
+                pVSrc = vi.value.get();
                 if (bUseIndex)
                     pVSrc = pVSrc->GetArrayElement(dwBXIndex);
                 if (!pVSrc)
@@ -5211,7 +5209,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                         SetError("Global variable not found");
                         return false;
                     }
-                    pVDst = vi.pDClass;
+                    pVDst = vi.value.get();
                 }
                 else
                 {
@@ -5386,7 +5384,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     break;
                 }
-                pVV = vi.pDClass;
+                pVV = vi.value.get();
                 // pVV = pVV->GetVarPointer();
                 // if(!pVV) { SetError("invalid ref"); break; }
                 if (pVV->IsReference())
@@ -5517,7 +5515,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     SetError("Global variable not found");
                     break;
                 }
-                vi.pDClass->Copy(pV);
+                vi.value->Copy(pV);
                 break;
             case LOCAL_VARIABLE:
                 pVar = SStack.Read(pRun_fi->stack_offset, *((uint32_t *)&pCodeBase[ip]));
@@ -5718,7 +5716,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     break;
                 }
                 ExpressionResult.ClearType();
-                ExpressionResult.Copy(vi.pDClass);
+                ExpressionResult.Copy(vi.value.get());
                 if (!ExpressionResult.Convert(VAR_STRING))
                 {
                     SetError("invalid type for attribute var");
@@ -6039,15 +6037,15 @@ bool COMPILER::ReadData(void *data_PTR, uint32_t data_size)
 
 bool COMPILER::FindReferencedVariable(DATA *pRef, uint32_t &var_index, uint32_t &array_index)
 {
-    VARINFO vi;
+    VarInfo vi;
 
     const uint32_t nVarNum = VarTab.GetVarNum();
     for (uint32_t n = 0; n < nVarNum; n++)
     {
         VarTab.GetVarX(vi, n);
-        if (!vi.pDClass->IsArray())
+        if (!vi.value->IsArray())
         {
-            if (pRef == vi.pDClass)
+            if (pRef == vi.value.get())
             {
                 var_index = n;
                 array_index = 0xffffffff;
@@ -6058,7 +6056,7 @@ bool COMPILER::FindReferencedVariable(DATA *pRef, uint32_t &var_index, uint32_t 
         {
             for (uint32_t i = 0; i < vi.elements; i++)
             {
-                if (pRef == vi.pDClass->GetArrayElement(i))
+                if (pRef == vi.value->GetArrayElement(i))
                 {
                     var_index = n;
                     array_index = i;
@@ -6072,7 +6070,7 @@ bool COMPILER::FindReferencedVariable(DATA *pRef, uint32_t &var_index, uint32_t 
 
 bool COMPILER::FindReferencedVariableByRootA(ATTRIBUTES *pA, uint32_t &var_index, uint32_t &array_index)
 {
-    VARINFO vi;
+    VarInfo vi;
 
     const uint32_t nVarNum = VarTab.GetVarNum();
     for (uint32_t n = 0; n < nVarNum; n++)
@@ -6080,9 +6078,9 @@ bool COMPILER::FindReferencedVariableByRootA(ATTRIBUTES *pA, uint32_t &var_index
         VarTab.GetVarX(vi, n);
         if (vi.type != VAR_OBJECT)
             continue;
-        if (!vi.pDClass->IsArray())
+        if (!vi.value->IsArray())
         {
-            if (pA == vi.pDClass->AttributesClass)
+            if (pA == vi.value->AttributesClass)
             {
                 var_index = n;
                 array_index = 0xffffffff; // ***
@@ -6093,7 +6091,7 @@ bool COMPILER::FindReferencedVariableByRootA(ATTRIBUTES *pA, uint32_t &var_index
         {
             for (uint32_t i = 0; i < vi.elements; i++)
             {
-                if (pA == vi.pDClass->GetArrayElement(i)->AttributesClass)
+                if (pA == vi.value->GetArrayElement(i)->AttributesClass)
                 {
                     var_index = n;
                     array_index = i;
@@ -6226,8 +6224,8 @@ bool COMPILER::ReadVariable(char *name, /* DWORD code,*/ bool bDim, uint32_t a_i
     uint32_t nElementsNum;
     ATTRIBUTES *pA;
     S_TOKEN_TYPE eType;
-    VARINFO vi;
-    VARINFO viRef;
+    VarInfo vi;
+    VarInfo viRef;
     DATA *pV;
     DATA *pVRef;
     entid_t eid;
@@ -6244,7 +6242,7 @@ bool COMPILER::ReadVariable(char *name, /* DWORD code,*/ bool bDim, uint32_t a_i
     else
     {
         VarTab.GetVarX(vi, var_code);
-        pV = vi.pDClass;
+        pV = vi.value.get();
     }
 
     if (!bDim) // skip this info for array elements
@@ -6265,7 +6263,7 @@ bool COMPILER::ReadVariable(char *name, /* DWORD code,*/ bool bDim, uint32_t a_i
                 // ???
                 // SetError("load size mismatch");
                 // return false;
-                vi.pDClass->SetElementsNum(nElementsNum);
+                vi.value->SetElementsNum(nElementsNum);
                 vi.elements = nElementsNum;
             }
     }
@@ -6350,7 +6348,7 @@ bool COMPILER::ReadVariable(char *name, /* DWORD code,*/ bool bDim, uint32_t a_i
             SetError("State read error");
             return false;
         }
-        pVRef = viRef.pDClass;
+        pVRef = viRef.value.get();
         if (array_index != 0xffffffff)
         {
             pVRef = pVRef->GetArrayElement(array_index);
@@ -6375,7 +6373,7 @@ bool COMPILER::ReadVariable(char *name, /* DWORD code,*/ bool bDim, uint32_t a_i
             SetError("State read error");
             return false;
         }
-        pVRef = viRef.pDClass;
+        pVRef = viRef.value.get();
         if (array_index != 0xffffffff)
         {
             pVRef = pVRef->GetArrayElement(array_index);
@@ -6532,7 +6530,7 @@ bool COMPILER::OnLoad()
 bool COMPILER::SaveState(std::fstream &fileS)
 {
     uint32_t n;
-    VARINFO vi;
+    VarInfo vi;
 
     delete pBuffer;
     pBuffer = nullptr;
@@ -6589,8 +6587,8 @@ bool COMPILER::SaveState(std::fstream &fileS)
     for (n = 0; n < nVarNum; n++)
     {
         VarTab.GetVar(vi, n);
-        SaveString(vi.name); // ***
-        SaveVariable(vi.pDClass);
+        SaveString(vi.name.c_str()); // ***
+        SaveVariable(vi.value.get());
     }
 
     uint64_t dw2;
@@ -7114,7 +7112,7 @@ void COMPILER::DeleteScriptFunction(uint32_t nFuncHandle)
 DATA *COMPILER::GetOperand(const char *pCodeBase, uint32_t &ip, S_TOKEN_TYPE *pTokenType)
 {
     uint32_t token_data_size;
-    VARINFO vi;
+    VarInfo vi;
     DATA *pVar;
 
     const S_TOKEN_TYPE sttResult = BC_TokenGet(ip, token_data_size);
@@ -7131,12 +7129,12 @@ DATA *COMPILER::GetOperand(const char *pCodeBase, uint32_t &ip, S_TOKEN_TYPE *pT
             SetError("Global variable not found");
             break;
         }
-        if (!vi.pDClass)
+        if (!vi.value.get())
         {
             SetError("invalid global variable");
             break;
         }
-        return vi.pDClass;
+        return vi.value.get();
     case LOCAL_VARIABLE:
         pVar = SStack.Read(pRun_fi->stack_offset, *((uint32_t *)&pCodeBase[ip]));
         if (pVar == nullptr)

--- a/src/apps/ENGINE/compiler.h
+++ b/src/apps/ENGINE/compiler.h
@@ -128,7 +128,7 @@ class COMPILER : public VIRTUAL_COMPILER
 
     FUNCINFO *pRun_fi; // running function info
     S_FUNCTAB FuncTab;
-    S_VARTAB VarTab;
+    VarTable VarTab;
     S_CLASSTAB ClassTab;
     S_DEFTAB DefTab;
     S_STACK SStack;

--- a/src/apps/ENGINE/compiler.h
+++ b/src/apps/ENGINE/compiler.h
@@ -126,8 +126,8 @@ class COMPILER : public VIRTUAL_COMPILER
     char *pDebExpBuffer;
     uint32_t nDebExpBufferSize;
 
-    FUNCINFO *pRun_fi; // running function info
-    S_FUNCTAB FuncTab;
+    FuncInfo *pRun_fi; // running function info
+    FuncTable FuncTab;
     VarTable VarTab;
     S_CLASSTAB ClassTab;
     S_DEFTAB DefTab;
@@ -327,7 +327,6 @@ class COMPILER : public VIRTUAL_COMPILER
     void AddRuntimeEvent();
 
     uint32_t SetScriptFunction(IFUNCINFO *pFuncInfo);
-    void DeleteScriptFunction(uint32_t nFuncHandle);
 
     bool CompileExpression(SEGMENT_DESC &Segment);
     bool CompileExpression_L0(SEGMENT_DESC &Segment);

--- a/src/apps/ENGINE/expression.cpp
+++ b/src/apps/ENGINE/expression.cpp
@@ -861,7 +861,7 @@ bool COMPILER::CompileExpression(SEGMENT_DESC &Segment)
 {
     uint32_t dwVarCode;
     VarInfo vi;
-    LVARINFO lvi;
+    LocalVarInfo lvi;
 
     const S_TOKEN_TYPE Token_type = CompileAuxiliaryTokens(Segment);
     if (Token_type == SEPARATOR)
@@ -914,11 +914,11 @@ bool COMPILER::CompileExpression(SEGMENT_DESC &Segment)
             {
                 FuncTab.GetVar(lvi, CurrentFuncCode, dwVarCode);
                 // check for possibilities of '[' operator
-                if (!lvi.bArray)
+                if (!lvi.IsArray())
                 {
                     if (lvi.type != VAR_REFERENCE)
                     {
-                        SetError(" B Invalid '[' operator, %s - isnt array", lvi.name);
+                        SetError(" B Invalid '[' operator, %s - isnt array", lvi.name.c_str());
                         return false;
                     }
                 }
@@ -1233,8 +1233,8 @@ bool COMPILER::CompileExpression_L7(SEGMENT_DESC &Segment)
     uint32_t dwVarCode;
     uint32_t dwAWCode;
     VarInfo vi;
-    LVARINFO lvi;
-    FUNCINFO fi;
+    LocalVarInfo lvi;
+    FuncInfo fi;
 
     bool bDynamicCall = false;
     switch (Token.GetType())
@@ -1480,11 +1480,11 @@ bool COMPILER::CompileExpression_L7(SEGMENT_DESC &Segment)
                 {
                     FuncTab.GetVar(lvi, CurrentFuncCode, dwVarCode);
                     // check for possibilities of '[' operator
-                    if (!lvi.bArray)
+                    if (!lvi.IsArray())
                     {
                         if (lvi.type != VAR_REFERENCE)
                         {
-                            SetError(" D Invalid '[' operator, %s - isnt array", lvi.name);
+                            SetError(" D Invalid '[' operator, %s - isnt array", lvi.name.c_str());
                             return false;
                         }
                     }

--- a/src/apps/ENGINE/expression.cpp
+++ b/src/apps/ENGINE/expression.cpp
@@ -25,7 +25,7 @@ bool COMPILER::BC_ProcessExpression(DATA *value)
     //--------------------------------------------------------------------------
     if (TokenIs(AND))
     {
-        VARINFO vi;
+        VarInfo vi;
 
         auto Token_type = BC_TokenGet();
         if (TokenType() != VARIABLE)
@@ -45,7 +45,7 @@ bool COMPILER::BC_ProcessExpression(DATA *value)
                 SetError("Global variable not found");
                 return false;
             }
-            pV = vi.pDClass;
+            pV = vi.value.get();
         }
         else
         {
@@ -422,7 +422,7 @@ void COMPILER::BC_ProcessExpression_L6(DATA *value, bool bSkip)
 
 void COMPILER::BC_ProcessExpression_L7(DATA *value, bool bSkip)
 {
-    VARINFO vi;
+    VarInfo vi;
     uint32_t var_code;
     long index;
     DATA array_index;
@@ -515,7 +515,7 @@ void COMPILER::BC_ProcessExpression_L7(DATA *value, bool bSkip)
                 SetError("Global variable not found");
                 return;
             }
-            pVV = vi.pDClass;
+            pVV = vi.value.get();
         }
         else
         {
@@ -607,7 +607,7 @@ void COMPILER::BC_ProcessExpression_L7(DATA *value, bool bSkip)
                 SetError("Global variable not found");
                 break;
             }
-            pV = vi.pDClass;
+            pV = vi.value.get();
         }
         else
         {
@@ -809,7 +809,7 @@ void COMPILER::BC_ProcessExpression_L7(DATA *value, bool bSkip)
                         SetError("Global variable not found");
                         break;
                     }
-                    pV = vi.pDClass;
+                    pV = vi.value.get();
                 }
                 else
                 {
@@ -860,7 +860,7 @@ void COMPILER::BC_ProcessExpression_L7(DATA *value, bool bSkip)
 bool COMPILER::CompileExpression(SEGMENT_DESC &Segment)
 {
     uint32_t dwVarCode;
-    VARINFO vi;
+    VarInfo vi;
     LVARINFO lvi;
 
     const S_TOKEN_TYPE Token_type = CompileAuxiliaryTokens(Segment);
@@ -900,12 +900,12 @@ bool COMPILER::CompileExpression(SEGMENT_DESC &Segment)
             {
                 VarTab.GetVarX(vi, dwVarCode);
                 // check for possibilities of '[' operator
-                if (!vi.bArray)
+                if (!vi.IsArray())
                 {
                     if (vi.type != VAR_REFERENCE)
                     {
                         SetError("EN: %d", vi.elements);
-                        SetError(" A Invalid '[' operator, %s - isnt array", vi.name);
+                        SetError(" A Invalid '[' operator, %s - isnt array", vi.name.c_str());
                         return false;
                     }
                 }
@@ -1232,7 +1232,7 @@ bool COMPILER::CompileExpression_L7(SEGMENT_DESC &Segment)
     S_TOKEN_TYPE sttFuncCallType;
     uint32_t dwVarCode;
     uint32_t dwAWCode;
-    VARINFO vi;
+    VarInfo vi;
     LVARINFO lvi;
     FUNCINFO fi;
 
@@ -1467,11 +1467,11 @@ bool COMPILER::CompileExpression_L7(SEGMENT_DESC &Segment)
                 {
                     VarTab.GetVarX(vi, dwVarCode);
                     // check for possibilities of '[' operator
-                    if (!vi.bArray)
+                    if (!vi.IsArray())
                     {
                         if (vi.type != VAR_REFERENCE)
                         {
-                            SetError(" C Invalid '[' operator, %s - isnt array", vi.name);
+                            SetError(" C Invalid '[' operator, %s - isnt array", vi.name.c_str());
                             return false;
                         }
                     }

--- a/src/apps/ENGINE/internal_functions.cpp
+++ b/src/apps/ENGINE/internal_functions.cpp
@@ -1347,7 +1347,12 @@ DATA *COMPILER::BC_CallIntFunction(uint32_t func_code, DATA *&pVResult, uint32_t
         pV->SetElementsNum(TempLong1);
 
         if (pV->nGlobalVarTableIndex != 0xffffffff)
-            VarTab.SetElementsNum(pV->nGlobalVarTableIndex, TempLong1);
+        {
+            if (!VarTab.SetElementsNum(pV->nGlobalVarTableIndex, TempLong1))
+            {
+                core.Trace("Unable to set elements num for %u", pV->nGlobalVarTableIndex);
+            }
+        }
 
         break;
 

--- a/src/apps/ENGINE/internal_functions.cpp
+++ b/src/apps/ENGINE/internal_functions.cpp
@@ -1347,7 +1347,7 @@ DATA *COMPILER::BC_CallIntFunction(uint32_t func_code, DATA *&pVResult, uint32_t
         pV->SetElementsNum(TempLong1);
 
         if (pV->nGlobalVarTableIndex != 0xffffffff)
-            VarTab.ArraySizeChanged(pV->nGlobalVarTableIndex, TempLong1);
+            VarTab.SetElementsNum(pV->nGlobalVarTableIndex, TempLong1);
 
         break;
 

--- a/src/apps/ENGINE/s_debug.cpp
+++ b/src/apps/ENGINE/s_debug.cpp
@@ -541,8 +541,8 @@ const char *S_DEBUG::ProcessExpression(const char *pExpression)
 uint32_t S_DEBUG::GetLineStatus(const char *_pFileName, uint32_t _linecode)
 {
     // nDebugTraceLineCode
-    if (core.Compiler->pRun_fi && core.Compiler->pRun_fi->decl_file_name)
-        if (_stricmp(core.Compiler->pRun_fi->decl_file_name, _pFileName) == 0)
+    if (core.Compiler->pRun_fi && !core.Compiler->pRun_fi->decl_file_name.empty())
+        if (_stricmp(core.Compiler->pRun_fi->decl_file_name.c_str(), _pFileName) == 0)
         {
             if (_linecode == core.Compiler->nDebugTraceLineCode)
                 return LST_CONTROL;

--- a/src/apps/ENGINE/s_functab.cpp
+++ b/src/apps/ENGINE/s_functab.cpp
@@ -205,20 +205,26 @@ bool FuncTable::GetVar(LocalVarInfo &lvi, size_t func_index, size_t var_index) c
     return true;
 }
 
-void FuncTable::AddTime(size_t func_index, uint64_t time)
+bool FuncTable::AddTime(size_t func_index, uint64_t time)
 {
-    if (func_index < funcs_.size())
+    if (func_index >= funcs_.size())
     {
-        funcs_[func_index].usage_time += time;
+        return false;
     }
+
+    funcs_[func_index].usage_time += time;
+    return true;
 }
 
-void FuncTable::AddCall(size_t func_index)
+bool FuncTable::AddCall(size_t func_index)
 {
-    if (func_index < funcs_.size())
+    if (func_index >= funcs_.size())
     {
-        ++funcs_[func_index].number_of_calls;
+        return false;
     }
+
+    ++funcs_[func_index].number_of_calls;
+    return true;
 }
 
 void FuncTable::Release()

--- a/src/apps/ENGINE/s_functab.cpp
+++ b/src/apps/ENGINE/s_functab.cpp
@@ -1,19 +1,9 @@
 #include "s_functab.h"
 
-FuncInfo::FuncInfo() : 
-  name(),
-  local_vars(),
-  segment_id(INVALID_SEGMENT_ID),
-  offset(INVALID_FUNC_OFFSET),
-  stack_offset(),
-  arguments(),
-  return_type(TVOID),
-  decl_file_name(),
-  decl_line(),
-  usage_time(),
-  number_of_calls(),
-  imported_func(),
-  extern_arguments()
+FuncInfo::FuncInfo()
+    : name(), local_vars(), segment_id(INVALID_SEGMENT_ID), offset(INVALID_FUNC_OFFSET), stack_offset(), arguments(),
+      return_type(TVOID), decl_file_name(), decl_line(), usage_time(), number_of_calls(), imported_func(),
+      extern_arguments()
 {
 }
 
@@ -78,7 +68,7 @@ bool FuncTable::GetFunc(FuncInfo &fi, size_t func_index) const
         {
             return false;
         }
-        
+
         fi = funcs_[func_index]; // copy func info
         return true;
     }

--- a/src/apps/ENGINE/s_functab.cpp
+++ b/src/apps/ENGINE/s_functab.cpp
@@ -33,16 +33,16 @@ size_t FuncTable::AddFunc(const FuncInfo &fi)
 
     auto result = hash_table_.try_emplace(fi.name, funcs_.size()); // find or create index
     auto func_index = result.first->second;
-    bool isNew = result.second;
+    bool is_new = result.second;
 
-    if (isNew) // newly created function, add to table
+    if (is_new) // newly created function, add to table
     {
         funcs_.push_back(fi);
     }
 
     auto &func = funcs_[func_index];
 
-    if (!isNew)
+    if (!is_new)
     {
         if (func.offset != INVALID_FUNC_OFFSET) // function already loaded
         {

--- a/src/apps/ENGINE/s_functab.cpp
+++ b/src/apps/ENGINE/s_functab.cpp
@@ -174,8 +174,8 @@ size_t FuncTable::FindVar(size_t func_index, const std::string &var_name) const
 
     const auto &vars = funcs_[func_index].local_vars;
     size_t hash = hasher_(var_name);
-    const auto result = std::find_if(vars.begin(), vars.end(), [this, hash, &var_name](const LocalVarInfo &var) {
-        return var.hash == hash && comparator_(var.name, var_name); // fast comparison
+    const auto result = std::find_if(vars.begin(), vars.end(), [hash, &var_name](const LocalVarInfo &var) {
+        return var.hash == hash && storm::iEquals(var.name, var_name); // fast comparison
     });
 
     if (result == vars.end())

--- a/src/apps/ENGINE/s_functab.h
+++ b/src/apps/ENGINE/s_functab.h
@@ -87,8 +87,8 @@ class FuncTable
     // get local var or arg by index
     bool GetVar(LocalVarInfo &lvi, size_t func_index, size_t var_index) const;
 
-    void AddTime(size_t func_index, uint64_t time);
-    void AddCall(size_t func_index);
+    bool AddTime(size_t func_index, uint64_t time);
+    bool AddCall(size_t func_index);
 
     void Release(); // clear table
 

--- a/src/apps/ENGINE/s_functab.h
+++ b/src/apps/ENGINE/s_functab.h
@@ -3,8 +3,8 @@
 #include "s_import_func.h"
 #include "s_vartab.h"
 #include "strutils.h"
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #define INVALID_FUNC_CODE 0xffffffff
 #define INVALID_FUNC_OFFSET 0xffffffff
@@ -18,8 +18,8 @@
 
 struct LocalVarInfo
 {
-    LocalVarInfo() = default;  
-    
+    LocalVarInfo() = default;
+
     bool IsArray()
     {
         return elements > 1;
@@ -34,7 +34,7 @@ struct LocalVarInfo
 struct FuncInfo
 {
     FuncInfo();
-    
+
     std::string name;
 
     std::vector<LocalVarInfo> local_vars;
@@ -66,14 +66,17 @@ class FuncTable
     ~FuncTable();
 
     size_t FindFunc(const std::string &func_name) const; // get func index by name
-    size_t AddFunc(const FuncInfo &fi); // add func to table, returns func index
-    bool GetFunc(FuncInfo &fi, size_t func_index) const; // get func by index, returns true if func is registered and loaded
+    size_t AddFunc(const FuncInfo &fi);                  // add func to table, returns func index
+    bool GetFunc(FuncInfo &fi,
+                 size_t func_index) const; // get func by index, returns true if func is registered and loaded
     bool GetFuncX(FuncInfo &fi, size_t func_index) const; // get func by index, returns true if func is registered
-    void InvalidateBySegmentID(uint32_t segment_id); // invalidate all segment's functions
-    
+    void InvalidateBySegmentID(uint32_t segment_id);      // invalidate all segment's functions
+
     bool SetFuncOffset(const std::string &func_name, uint32_t offset); // set func's compiler offset
     bool AddFuncVar(size_t func_index, const LocalVarInfo &lvi);       // add local var to func
-    bool AddFuncArg(size_t func_index, const LocalVarInfo &lvi, bool is_extern = false); // add arg to func (must precede all regular local vars in order not to break compiler logic)
+    bool AddFuncArg(size_t func_index, const LocalVarInfo &lvi,
+                    bool is_extern = false); // add arg to func (must precede all regular local vars in order not to
+                                             // break compiler logic)
     size_t FindVar(size_t func_index, const std::string &var_name) const; // get func's local var or arg index by name
     bool GetVar(LocalVarInfo &lvi, size_t func_index, size_t var_index) const; // get local var or arg by index
 
@@ -83,7 +86,6 @@ class FuncTable
     void Release(); // clear table
 
   private:
-
     std::vector<FuncInfo> funcs_;
     CaseInsensitiveStringHasher hasher_;
     CaseInsensitiveStringComparator comparator_;

--- a/src/apps/ENGINE/s_functab.h
+++ b/src/apps/ENGINE/s_functab.h
@@ -65,20 +65,27 @@ class FuncTable
     FuncTable() = default;
     ~FuncTable();
 
-    size_t FindFunc(const std::string &func_name) const; // get func index by name
-    size_t AddFunc(const FuncInfo &fi);                  // add func to table, returns func index
-    bool GetFunc(FuncInfo &fi,
-                 size_t func_index) const; // get func by index, returns true if func is registered and loaded
-    bool GetFuncX(FuncInfo &fi, size_t func_index) const; // get func by index, returns true if func is registered
-    void InvalidateBySegmentID(uint32_t segment_id);      // invalidate all segment's functions
+    // get func index by name
+    size_t FindFunc(const std::string &func_name) const;
+    // add func to table, returns func index
+    size_t AddFunc(const FuncInfo &fi);
+    // get func by index, returns true if func is registered and loaded
+    bool GetFunc(FuncInfo &fi, size_t func_index) const;
+    // get func by index, returns true if func is registered
+    bool GetFuncX(FuncInfo &fi, size_t func_index) const;
+    // invalidate all segment's functions
+    void InvalidateBySegmentID(uint32_t segment_id);
 
-    bool SetFuncOffset(const std::string &func_name, uint32_t offset); // set func's compiler offset
-    bool AddFuncVar(size_t func_index, const LocalVarInfo &lvi);       // add local var to func
-    bool AddFuncArg(size_t func_index, const LocalVarInfo &lvi,
-                    bool is_extern = false); // add arg to func (must precede all regular local vars in order not to
-                                             // break compiler logic)
-    size_t FindVar(size_t func_index, const std::string &var_name) const; // get func's local var or arg index by name
-    bool GetVar(LocalVarInfo &lvi, size_t func_index, size_t var_index) const; // get local var or arg by index
+    // set func's compiler offset
+    bool SetFuncOffset(const std::string &func_name, uint32_t offset);
+    // add local var to func
+    bool AddFuncVar(size_t func_index, const LocalVarInfo &lvi);
+    // add arg to func (must precede all regular local vars in order not to break compiler logic)
+    bool AddFuncArg(size_t func_index, const LocalVarInfo &lvi, bool is_extern = false);
+    // get func's local var or arg index by name
+    size_t FindVar(size_t func_index, const std::string &var_name) const;
+    // get local var or arg by index
+    bool GetVar(LocalVarInfo &lvi, size_t func_index, size_t var_index) const;
 
     void AddTime(size_t func_index, uint64_t time);
     void AddCall(size_t func_index);

--- a/src/apps/ENGINE/s_functab.h
+++ b/src/apps/ENGINE/s_functab.h
@@ -2,9 +2,10 @@
 
 #include "s_import_func.h"
 #include "s_vartab.h"
+#include "strutils.h"
 #include <vector>
+#include <unordered_map>
 
-#define FUNC_BUFFER_BLOCK_SIZE 1024
 #define INVALID_FUNC_CODE 0xffffffff
 #define INVALID_FUNC_OFFSET 0xffffffff
 #define INTERNAL_SEGMENT_ID 0xffffffff
@@ -15,79 +16,76 @@
 // when segment_id is INTERNAL_SEGMENT_ID, this function is internal and offset
 // means internal function number
 
-struct LVARINFO
+struct LocalVarInfo
 {
+    LocalVarInfo() = default;  
+    
+    bool IsArray()
+    {
+        return elements > 1;
+    }
+
+    std::string name;
+    size_t hash; // for faster comparison
     S_TOKEN_TYPE type;
-    uint32_t hash;
-    const char *name;
-    uint32_t elements;
-    bool bArray;
+    size_t elements;
 };
 
-struct FUNCINFO
+struct FuncInfo
 {
+    FuncInfo();
+    
+    std::string name;
+
+    std::vector<LocalVarInfo> local_vars;
+
+    // compiler info
     uint32_t segment_id;
     uint32_t offset;
-    uint32_t hash;
-    const char *name;
-    uint32_t arguments;
-    uint32_t var_num;
     uint32_t stack_offset;
-    std::vector<LVARINFO> pLocal;
+    uint32_t arguments;
     S_TOKEN_TYPE return_type;
-    const char *decl_file_name;
+
+    // debug info
+    std::string decl_file_name;
     uint32_t decl_line;
-    uint32_t code;
-    double fTimeUsage;
-    uint32_t nNumberOfCalls;
-    SIMPORTFUNC pImportedFunc;
-    uint32_t ext_args;
+
+    // profile info
+    uint64_t usage_time;
+    uint32_t number_of_calls;
+
+    // imported func info
+    SIMPORTFUNC imported_func;
+    uint32_t extern_arguments;
 };
 
-#define HASHT_SIZE 256
-
-struct HASHLINE
+class FuncTable
 {
-    HASHLINE()
-    {
-        nNumElements = 0;
-    }
-    uint32_t nNumElements;
-    std::vector<uint32_t> pElements;
-};
-
-class S_FUNCTAB
-{
-    uint32_t Buffer_size;
-    uint32_t Func_num;
-    std::vector<FUNCINFO> pTable;
-    // bool bKeepName;
-
-    HASHLINE HashLine[HASHT_SIZE];
-
   public:
-    S_FUNCTAB();
-    ~S_FUNCTAB();
-    uint32_t GetFuncNum()
-    {
-        return Func_num;
-    };
-    uint32_t AddFunc(const FUNCINFO &fi);
-    bool GetFunc(FUNCINFO &fi, uint32_t func_code);  // return true if func registred and loaded
-    bool GetFuncX(FUNCINFO &fi, uint32_t func_code); // return true if func registred
-    uint32_t MakeHashValue(const char *string);
-    // void  KeepNameMode(bool on){bKeepName = on;};
-    void Release();
-    void InvalidateBySegmentID(uint32_t segment_id);
-    uint32_t FindFunc(const char *func_name);
-    bool SetFuncOffset(const char *func_name, uint32_t offset);
-    bool AddFuncVar(uint32_t func_code, LVARINFO &lvi);
-    bool AddFuncArg(uint32_t func_code, LVARINFO &lvi, bool bExt = false);
-    uint32_t FindVar(uint32_t func_code, const char *var_name);
-    void AddTime(uint32_t func_code, uint64_t time);
-    void SetTimeUsage(uint32_t func_code, double f);
-    void AddCall(uint32_t func_code);
-    void InvalidateFunction(uint32_t nFuncHandle);
-    void UpdateHashTable(uint32_t code, uint32_t hash, bool in);
-    bool GetVar(LVARINFO &lvi, uint32_t func_code, uint32_t var_code);
+    FuncTable() = default;
+    ~FuncTable();
+
+    size_t FindFunc(const std::string &func_name) const; // get func index by name
+    size_t AddFunc(const FuncInfo &fi); // add func to table, returns func index
+    bool GetFunc(FuncInfo &fi, size_t func_index) const; // get func by index, returns true if func is registered and loaded
+    bool GetFuncX(FuncInfo &fi, size_t func_index) const; // get func by index, returns true if func is registered
+    void InvalidateBySegmentID(uint32_t segment_id); // invalidate all segment's functions
+    
+    bool SetFuncOffset(const std::string &func_name, uint32_t offset); // set func's compiler offset
+    bool AddFuncVar(size_t func_index, const LocalVarInfo &lvi);       // add local var to func
+    bool AddFuncArg(size_t func_index, const LocalVarInfo &lvi, bool is_extern = false); // add arg to func (must precede all regular local vars in order not to break compiler logic)
+    size_t FindVar(size_t func_index, const std::string &var_name) const; // get func's local var or arg index by name
+    bool GetVar(LocalVarInfo &lvi, size_t func_index, size_t var_index) const; // get local var or arg by index
+
+    void AddTime(size_t func_index, uint64_t time);
+    void AddCall(size_t func_index);
+
+    void Release(); // clear table
+
+  private:
+
+    std::vector<FuncInfo> funcs_;
+    CaseInsensitiveStringHasher hasher_;
+    CaseInsensitiveStringComparator comparator_;
+    std::unordered_map<std::string, size_t, CaseInsensitiveStringHasher, CaseInsensitiveStringComparator> hash_table_;
 };

--- a/src/apps/ENGINE/s_functab.h
+++ b/src/apps/ENGINE/s_functab.h
@@ -2,7 +2,7 @@
 
 #include "s_import_func.h"
 #include "s_vartab.h"
-#include "strutils.h"
+#include "storm/string_compare.hpp"
 #include <unordered_map>
 #include <vector>
 
@@ -94,7 +94,6 @@ class FuncTable
 
   private:
     std::vector<FuncInfo> funcs_;
-    CaseInsensitiveStringHasher hasher_;
-    CaseInsensitiveStringComparator comparator_;
-    std::unordered_map<std::string, size_t, CaseInsensitiveStringHasher, CaseInsensitiveStringComparator> hash_table_;
+    storm::iStrHasher hasher_;
+    std::unordered_map<std::string, size_t, storm::iStrHasher, storm::iStrComparator> hash_table_;
 };

--- a/src/apps/ENGINE/s_vartab.cpp
+++ b/src/apps/ENGINE/s_vartab.cpp
@@ -4,6 +4,25 @@ VarInfo::VarInfo() : name(), type(TVOID), value(), elements(0), segment_id(INVAL
 {
 }
 
+VarInfo::VarInfo(const VarInfo &other)
+    : name(other.name), type(other.type), value(), elements(other.elements), segment_id(other.segment_id)
+{
+}
+
+VarInfo &VarInfo::operator=(const VarInfo &other)
+{
+    if (this != &other)
+    {
+        name = other.name;
+        type = other.type;
+        value = {};
+        elements = other.elements;
+        segment_id = other.segment_id;
+    }
+
+    return *this;
+}
+
 VarTable::~VarTable()
 {
     Release();
@@ -37,7 +56,7 @@ size_t VarTable::AddVar(const VarInfo &vi)
         var = vi; // variable exists, but was unloaded, copy data
     }
 
-    var.value = std::make_shared<DATA>();
+    var.value = std::make_unique<DATA>();
     var.value->SetVCompiler(vc_);
     var.value->SetType(var.type, var.elements);
     var.value->SetGlobalVarTableIndex(var_index); // todo change to size_t
@@ -45,31 +64,29 @@ size_t VarTable::AddVar(const VarInfo &vi)
     return var_index;
 }
 
-bool VarTable::GetVar(VarInfo &vi, size_t var_index) const
+const VarInfo *VarTable::GetVar(size_t var_index) const
 {
     if (var_index >= vars_.size())
     {
-        return false;
+        return nullptr;
     }
 
     if (vars_[var_index].segment_id == INVALID_SEGMENT_ID)
     {
-        return false;
+        return nullptr;
     }
 
-    vi = vars_[var_index]; // copy var info
-    return true;
+    return &vars_[var_index];
 }
 
-bool VarTable::GetVarX(VarInfo &vi, size_t var_index) const
+const VarInfo *VarTable::GetVarX(size_t var_index) const
 {
     if (var_index >= vars_.size())
     {
-        return false;
+        return nullptr;
     }
 
-    vi = vars_[var_index]; // copy var info
-    return true;
+    return &vars_[var_index];
 }
 
 void VarTable::InvalidateBySegmentID(uint32_t segment_id)

--- a/src/apps/ENGINE/s_vartab.cpp
+++ b/src/apps/ENGINE/s_vartab.cpp
@@ -18,16 +18,16 @@ size_t VarTable::AddVar(const VarInfo &vi)
 
     auto result = hash_table_.try_emplace(vi.name, vars_.size()); // find or create index
     auto var_index = result.first->second;
-    bool isNew = result.second;
+    bool is_new = result.second;
 
-    if (isNew) // newly created var, add to table
+    if (is_new) // newly created var, add to table
     {
         vars_.push_back(vi);
     }
 
     auto &var = vars_[var_index];
 
-    if (!isNew)
+    if (!is_new)
     {
         if (var.segment_id != INVALID_SEGMENT_ID) // variable already loaded
         {

--- a/src/apps/ENGINE/s_vartab.cpp
+++ b/src/apps/ENGINE/s_vartab.cpp
@@ -1,231 +1,121 @@
 #include "s_vartab.h"
-//#include <string.h>
 
-#define VTMAKEHASHINDEX(x) (x & 0xff)
-
-S_VARTAB::S_VARTAB()
+VarInfo::VarInfo() : name(),
+  type(TVOID),
+  value(),
+  elements(0),
+  segment_id(INVALID_SEGMENT_ID)
 {
-    Buffer_size = 0;
-    Var_num = 0;
-    //    bKeepName = false;
-    Global_var_num = 0;
-    for (uint32_t n = 0; n < VTHASHT_SIZE; n++)
-    {
-        HashLine[n].nNumElements = 0;
-    }
 }
 
-S_VARTAB::~S_VARTAB()
+VarTable::~VarTable()
 {
     Release();
 }
 
-void S_VARTAB::Release()
+size_t VarTable::AddVar(const VarInfo &vi)
 {
-    uint32_t n;
-    for (n = 0; n < Var_num; n++)
+    if (vi.name.empty())
     {
-        delete pTable[n].pDClass;
-        delete pTable[n].name;
-    }
-    pTable.clear();
-    Buffer_size = 0;
-    Var_num = 0;
-    for (n = 0; n < VTHASHT_SIZE; n++)
-    {
-        HashLine[n].nNumElements = 0;
-        HashLine[n].pElements.clear();
-    }
-}
-
-bool S_VARTAB::GetVar(VARINFO &vi, uint32_t var_code)
-{
-    if (var_code >= Var_num)
-        return false;
-    if (pTable[var_code].segment_id == INVALID_SEGMENT_ID)
-        return false;
-    vi = pTable[var_code];
-    return true;
-}
-
-bool S_VARTAB::GetVarX(VARINFO &vi, uint32_t var_code)
-{
-    if (var_code >= Var_num)
-        return false;
-    vi = pTable[var_code];
-    return true;
-}
-
-uint32_t S_VARTAB::AddVar(VARINFO &vi)
-{
-    if (vi.name == nullptr)
         return INVALID_VAR_CODE;
-
-    // trace("%s : %d",vi.name,(long)vi.bArray);
-
-    const auto hash = MakeHashValue(vi.name);
-
-    for (uint32_t n = 0; n < Var_num; n++)
-    {
-        if (pTable[n].hash == hash)
-            if (_stricmp(pTable[n].name, vi.name) == 0)
-            {
-                // variable with such name already registred,
-                if (pTable[n].segment_id == INVALID_SEGMENT_ID)
-                {
-                    UpdateHashTable(n, hash, true);
-                    // but segment is unloaded
-                    pTable[n].segment_id = vi.segment_id;
-
-                    // if the same type and dimension - just return code
-                    if (pTable[n].type == vi.type && pTable[n].elements == vi.elements)
-                        return n;
-
-                    // name the same, but type or dimension different - recreate (keep old name and hash)
-                    pTable[n].elements = vi.elements;
-                    pTable[n].type = vi.type;
-                    delete pTable[n].pDClass;
-
-                    pTable[n].pDClass = new DATA;
-                    pTable[n].pDClass->SetVCompiler(pVCompiler);
-                    pTable[n].pDClass->SetType(vi.type, vi.elements);
-
-                    return n;
-                }
-                // and already exist
-                // this is 'double variable name' error
-                // (possible becose hash function error), user must rename variable
-                return INVALID_VAR_CODE;
-            }
     }
-    // function not found, add anew one
-    // adjust buffer size
-    if (Var_num >= Buffer_size)
+
+    auto result = hash_table_.try_emplace(vi.name, vars_.size()); // find or create index
+    auto var_index = result.first->second;
+    bool isNew = result.second;
+
+    if (isNew) // newly created var, add to table
     {
-        Buffer_size += VAR_BUFFER_BLOCK_SIZE;
-        pTable.resize(Buffer_size);
+        vars_.push_back(vi);
     }
-    // pTable[Var_num] = vi;
-    pTable[Var_num].bArray = vi.bArray;
-    pTable[Var_num].segment_id = vi.segment_id;
-    pTable[Var_num].elements = vi.elements;
-    pTable[Var_num].type = vi.type;
-    pTable[Var_num].hash = hash;
-    pTable[Var_num].name = nullptr;
 
-    pTable[Var_num].pDClass = new DATA;
-    pTable[Var_num].pDClass->SetVCompiler(pVCompiler);
-    pTable[Var_num].pDClass->SetType(vi.type, vi.elements);
-    pTable[Var_num].pDClass->SetGlobalVarTableIndex(Var_num);
+    auto &var = vars_[var_index];
 
-    UpdateHashTable(Var_num, hash, true);
-
-    if constexpr (true) // bKeepName)
+    if (!isNew)
     {
-        if (vi.name)
+        if (var.segment_id != INVALID_SEGMENT_ID) // variable already loaded
         {
-            const auto len = strlen(vi.name) + 1;
-            pTable[Var_num].name = new char[len];
-            memcpy(pTable[Var_num].name, vi.name, len);
+            return INVALID_VAR_CODE;
         }
+        
+        var = vi; // variable exists, but was unloaded, copy data
     }
-    Var_num++;
 
-    return (Var_num - 1);
+    var.value = std::make_shared<DATA>();
+    var.value->SetVCompiler(vc_);
+    var.value->SetType(var.type, var.elements);
+    var.value->SetGlobalVarTableIndex(var_index); // todo change to size_t
+
+    return var_index;
 }
 
-uint32_t S_VARTAB::MakeHashValue(const char *string)
+bool VarTable::GetVar(VarInfo &vi, size_t var_index) const
 {
-    uint32_t hval = 0;
-    while (*string != 0)
+    if (var_index >= vars_.size())
     {
-        auto v = *string++;
-        if ('A' <= v && v <= 'Z')
-            v += 'a' - 'A'; // case independent
-        hval = (hval << 4) + static_cast<unsigned long>(v);
-        const uint32_t g = hval & (static_cast<unsigned long>(0xf) << (32 - 4));
-        if (g != 0)
-        {
-            hval ^= g >> (32 - 8);
-            hval ^= g;
-        }
-    }
-    return hval;
-}
-
-void S_VARTAB::InvalidateBySegmentID(uint32_t segment_id)
-{
-    for (uint32_t n = 0; n < Var_num; n++)
-    {
-        if (pTable[n].segment_id != segment_id)
-            continue;
-        pTable[n].segment_id = INVALID_SEGMENT_ID;
-        UpdateHashTable(n, pTable[n].hash, false);
-    }
-}
-
-uint32_t S_VARTAB::FindVar(const char *var_name)
-{
-    if (var_name == nullptr)
-        return INVALID_VAR_CODE;
-    const auto hash = MakeHashValue(var_name);
-    const auto hash_index = VTMAKEHASHINDEX(hash);
-    for (uint32_t n = 0; n < HashLine[hash_index].nNumElements; n++)
-    {
-        const auto ni = HashLine[hash_index].pElements[n];
-        if (pTable[ni].hash == hash) // return n;
-            if (_stricmp(pTable[ni].name, var_name) == 0)
-                return ni;
-    }
-    return INVALID_VAR_CODE;
-    /*
-
-    uint32_t n;
-    uint32_t hash;
-    if(var_name == 0) return INVALID_VAR_CODE;
-    hash = MakeHashValue(var_name);
-    for(n=0;n<Var_num;n++)
-    {
-      if(pTable[n].hash == hash) //return n;
-      if(_stricmp(pTable[n].name,var_name)==0) return n;
-    }
-    return INVALID_VAR_CODE;*/
-}
-
-bool S_VARTAB::ArraySizeChanged(uint32_t nIndex, uint32_t nNewSize)
-{
-    if (nIndex >= Var_num)
-        return false;
-    if (!pTable[nIndex].pDClass->IsArray())
-    {
-        // trace("ERROR: invalid variable type for 'ChangeArraySize(?)' function");
         return false;
     }
-    pTable[nIndex].elements = nNewSize;
+
+    if (vars_[var_index].segment_id == INVALID_SEGMENT_ID)
+    {
+        return false;
+    }
+
+    vi = vars_[var_index]; // copy var info
     return true;
 }
 
-void S_VARTAB::UpdateHashTable(uint32_t code, uint32_t hash, bool in)
+bool VarTable::GetVarX(VarInfo &vi, size_t var_index) const
 {
-    const auto hash_index = VTMAKEHASHINDEX(hash);
-
-    for (uint32_t n = 0; n < HashLine[hash_index].nNumElements; n++)
+    if (var_index >= vars_.size())
     {
-        if (HashLine[hash_index].pElements[n] != code)
-            continue;
-        if (!in)
+        return false;
+    }
+
+    vi = vars_[var_index]; // copy var info
+    return true;
+}
+
+void VarTable::InvalidateBySegmentID(uint32_t segment_id)
+{
+    for (auto &vi : vars_)
+    {
+        if (vi.segment_id == segment_id)
         {
-            // take element out of list
-            HashLine[hash_index].pElements[n] = HashLine[hash_index].pElements[HashLine[hash_index].nNumElements - 1];
-            HashLine[hash_index].nNumElements--;
-            HashLine[hash_index].pElements.resize(HashLine[hash_index].nNumElements);
-            return;
+            vi.segment_id = INVALID_SEGMENT_ID; // hash is not deleted from table
         }
+    }
+}
+
+size_t VarTable::FindVar(const std::string &var_name) const
+{
+    auto result = hash_table_.find(var_name);
+
+    if (result == hash_table_.end())
+    {
+        return INVALID_VAR_CODE;
+    }
+
+    return result->second;
+}
+
+void VarTable::SetElementsNum(size_t var_index, size_t elements_num)
+{
+    if (var_index >= vars_.size())
+    {
         return;
-        // ok, already in list (? possible)
     }
-    // not in list - add
-    HashLine[hash_index].nNumElements++;
-    HashLine[hash_index].pElements.resize(HashLine[hash_index].nNumElements);
-    HashLine[hash_index].pElements[HashLine[hash_index].nNumElements - 1] = code;
+
+    if (!vars_[var_index].value->IsArray())
+    {
+        return;
+    }
+
+    vars_[var_index].elements = elements_num;
+}
+
+void VarTable::Release()
+{
+    vars_.clear();
+    hash_table_.clear();
 }

--- a/src/apps/ENGINE/s_vartab.cpp
+++ b/src/apps/ENGINE/s_vartab.cpp
@@ -1,10 +1,6 @@
 #include "s_vartab.h"
 
-VarInfo::VarInfo() : name(),
-  type(TVOID),
-  value(),
-  elements(0),
-  segment_id(INVALID_SEGMENT_ID)
+VarInfo::VarInfo() : name(), type(TVOID), value(), elements(0), segment_id(INVALID_SEGMENT_ID)
 {
 }
 
@@ -37,7 +33,7 @@ size_t VarTable::AddVar(const VarInfo &vi)
         {
             return INVALID_VAR_CODE;
         }
-        
+
         var = vi; // variable exists, but was unloaded, copy data
     }
 

--- a/src/apps/ENGINE/s_vartab.cpp
+++ b/src/apps/ENGINE/s_vartab.cpp
@@ -112,19 +112,20 @@ size_t VarTable::FindVar(const std::string &var_name) const
     return result->second;
 }
 
-void VarTable::SetElementsNum(size_t var_index, size_t elements_num)
+bool VarTable::SetElementsNum(size_t var_index, size_t elements_num)
 {
     if (var_index >= vars_.size())
     {
-        return;
+        return false;
     }
 
     if (!vars_[var_index].value->IsArray())
     {
-        return;
+        return false;
     }
 
     vars_[var_index].elements = elements_num;
+    return true;
 }
 
 void VarTable::Release()

--- a/src/apps/ENGINE/s_vartab.h
+++ b/src/apps/ENGINE/s_vartab.h
@@ -51,8 +51,8 @@ class VarTable
     void InvalidateBySegmentID(uint32_t segment_id);
     // get var index by name
     size_t FindVar(const std::string &var_name) const;
-    // set var's array size
-    void SetElementsNum(size_t var_index, size_t elements_num);
+    // set var's array size, returns true if successful
+    bool SetElementsNum(size_t var_index, size_t elements_num);
     // clear table
     void Release();
 

--- a/src/apps/ENGINE/s_vartab.h
+++ b/src/apps/ENGINE/s_vartab.h
@@ -14,15 +14,18 @@
 struct VarInfo
 {
     VarInfo();
+    VarInfo(const VarInfo &other);
+    VarInfo(VarInfo &&other) = default;
+    VarInfo &operator=(const VarInfo &other);
 
-    bool IsArray()
+    bool IsArray() const
     {
         return elements > 1;
     }
 
     std::string name;
     S_TOKEN_TYPE type;
-    std::shared_ptr<DATA> value;
+    std::unique_ptr<DATA> value;
     size_t elements;
     uint32_t segment_id;
 };
@@ -38,13 +41,20 @@ class VarTable
         return vars_.size();
     };
 
-    size_t AddVar(const VarInfo &vi);                  // add var to table, returns var index
-    bool GetVar(VarInfo &vi, size_t var_index) const;  // get var by index, returns true if var registered and loaded
-    bool GetVarX(VarInfo &vi, size_t var_index) const; // get var by index, return true if var registered
-    void InvalidateBySegmentID(uint32_t segment_id);   // invalidate all segment's vars
-    size_t FindVar(const std::string &var_name) const; // get var index by name
-    void SetElementsNum(size_t var_index, size_t elements_num); // set var's array size
-    void Release();                                             // clear table
+    // add var to table, returns var index
+    size_t AddVar(const VarInfo &vi);
+    // get var by index, returns non-null ptr if var is registered and loaded
+    const VarInfo *GetVar(size_t var_index) const;
+    // get var by index, returns non-null ptr if var is registered
+    const VarInfo *GetVarX(size_t var_index) const;
+    // invalidate all segment's vars
+    void InvalidateBySegmentID(uint32_t segment_id);
+    // get var index by name
+    size_t FindVar(const std::string &var_name) const;
+    // set var's array size
+    void SetElementsNum(size_t var_index, size_t elements_num);
+    // clear table
+    void Release();
 
     void SetVCompiler(VIRTUAL_COMPILER *vc)
     {

--- a/src/apps/ENGINE/s_vartab.h
+++ b/src/apps/ENGINE/s_vartab.h
@@ -1,83 +1,61 @@
 #pragma once
 
 #include "data.h"
+#include "strutils.h"
 #include <vector>
+#include <unordered_map>
 
 // when segment_id is INVALID_SEGMENT_ID, variable segment is unloaded
 // and variable value and type undefined
 
-#define VAR_BUFFER_BLOCK_SIZE 1024
 #define INVALID_VAR_CODE 0xffffffff
 #define INVALID_SEGMENT_ID 0xffffffff
 
-struct VARINFO
+struct VarInfo
 {
-    VARINFO()
+    VarInfo();
+
+    bool IsArray()
     {
-        pDClass = nullptr;
-        name = nullptr;
-        type = UNKNOWN;
-        bArray = false;
-        elements = 0;
-        segment_id = INVALID_SEGMENT_ID;
-        hash = 0;
-    };
-    uint32_t segment_id;
-    uint32_t hash;
-    DATA *pDClass;
-    char *name;
-    uint32_t elements;
-    S_TOKEN_TYPE type;
-    bool bArray;
-};
-
-class S_DEBUG;
-
-#define VTHASHT_SIZE 256
-
-struct VTHASHLINE
-{
-    VTHASHLINE()
-    {
-        nNumElements = 0;
-    };
-    uint32_t nNumElements;
-    std::vector<uint32_t> pElements;
-};
-
-class S_VARTAB
-{
-    friend S_DEBUG;
-
-    uint32_t Buffer_size;
-    uint32_t Var_num;
-    std::vector<VARINFO> pTable;
-    // bool bKeepName;
-    uint32_t Global_var_num;
-    VIRTUAL_COMPILER *pVCompiler;
-    VTHASHLINE HashLine[VTHASHT_SIZE];
-
-  public:
-    S_VARTAB();
-    ~S_VARTAB();
-    uint32_t GetVarNum()
-    {
-        return Var_num;
-    };
-    uint32_t AddVar(VARINFO &vi);
-    bool GetVar(VARINFO &vi, uint32_t var_code);  // return true if var registred and loaded
-    bool GetVarX(VARINFO &vi, uint32_t var_code); // return true if var registred
-    uint32_t MakeHashValue(const char *string);
-    //    void  KeepNameMode(bool on){bKeepName = on;};
-    void Release();
-    void InvalidateBySegmentID(uint32_t segment_id);
-    uint32_t FindVar(const char *var_name);
-    void SetElementsNum(uint32_t var_code, uint32_t elements_num){};
-    void SetType(uint32_t var_code, uint32_t type){};
-    void SetVCompiler(VIRTUAL_COMPILER *pvc)
-    {
-        pVCompiler = pvc;
+        return elements > 1;
     }
-    bool ArraySizeChanged(uint32_t nIndex, uint32_t nNewSize);
-    void UpdateHashTable(uint32_t code, uint32_t hash, bool in);
+
+    std::string name;
+    S_TOKEN_TYPE type;
+    std::shared_ptr<DATA> value;
+    size_t elements;
+    uint32_t segment_id;
+};
+
+class VarTable
+{
+  public:
+
+    VarTable() = default;
+    ~VarTable();
+
+    size_t GetVarNum() const // get var table size
+    {
+        return vars_.size();
+    };
+
+    size_t AddVar(const VarInfo &vi); // add var to table, returns var index
+    bool GetVar(VarInfo &vi, size_t var_index) const; // get var by index, returns true if var registered and loaded
+    bool GetVarX(VarInfo &vi, size_t var_index) const; // get var by index, return true if var registered
+    void InvalidateBySegmentID(uint32_t segment_id); // invalidate all segment's vars
+    size_t FindVar(const std::string &var_name) const; // get var index by name
+    void SetElementsNum(size_t var_index, size_t elements_num); // set var's array size
+    void Release(); // clear table
+
+    void SetVCompiler(VIRTUAL_COMPILER *vc)
+    {
+        vc_ = vc;
+    }
+
+  private:
+
+    std::vector<VarInfo> vars_;
+    std::unordered_map<std::string, size_t, CaseInsensitiveStringHasher, CaseInsensitiveStringComparator>
+        hash_table_; // name to index mapping
+    VIRTUAL_COMPILER *vc_;
 };

--- a/src/apps/ENGINE/s_vartab.h
+++ b/src/apps/ENGINE/s_vartab.h
@@ -2,8 +2,8 @@
 
 #include "data.h"
 #include "strutils.h"
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 // when segment_id is INVALID_SEGMENT_ID, variable segment is unloaded
 // and variable value and type undefined
@@ -30,7 +30,6 @@ struct VarInfo
 class VarTable
 {
   public:
-
     VarTable() = default;
     ~VarTable();
 
@@ -39,13 +38,13 @@ class VarTable
         return vars_.size();
     };
 
-    size_t AddVar(const VarInfo &vi); // add var to table, returns var index
-    bool GetVar(VarInfo &vi, size_t var_index) const; // get var by index, returns true if var registered and loaded
+    size_t AddVar(const VarInfo &vi);                  // add var to table, returns var index
+    bool GetVar(VarInfo &vi, size_t var_index) const;  // get var by index, returns true if var registered and loaded
     bool GetVarX(VarInfo &vi, size_t var_index) const; // get var by index, return true if var registered
-    void InvalidateBySegmentID(uint32_t segment_id); // invalidate all segment's vars
+    void InvalidateBySegmentID(uint32_t segment_id);   // invalidate all segment's vars
     size_t FindVar(const std::string &var_name) const; // get var index by name
     void SetElementsNum(size_t var_index, size_t elements_num); // set var's array size
-    void Release(); // clear table
+    void Release();                                             // clear table
 
     void SetVCompiler(VIRTUAL_COMPILER *vc)
     {
@@ -53,7 +52,6 @@ class VarTable
     }
 
   private:
-
     std::vector<VarInfo> vars_;
     std::unordered_map<std::string, size_t, CaseInsensitiveStringHasher, CaseInsensitiveStringComparator>
         hash_table_; // name to index mapping

--- a/src/apps/ENGINE/s_vartab.h
+++ b/src/apps/ENGINE/s_vartab.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "data.h"
-#include "strutils.h"
+#include "storm/string_compare.hpp"
 #include <unordered_map>
 #include <vector>
 
@@ -63,7 +63,7 @@ class VarTable
 
   private:
     std::vector<VarInfo> vars_;
-    std::unordered_map<std::string, size_t, CaseInsensitiveStringHasher, CaseInsensitiveStringComparator>
+    std::unordered_map<std::string, size_t, storm::iStrHasher, storm::iStrComparator>
         hash_table_; // name to index mapping
     VIRTUAL_COMPILER *vc_;
 };

--- a/src/libs/Common_h/strutils.h
+++ b/src/libs/Common_h/strutils.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <algorithm>
 
 namespace TOREMOVE
 {
@@ -26,3 +27,32 @@ inline void rtrim(std::string &str)
     }
 }
 } // namespace TOREMOVE
+
+class CaseInsensitiveStringHasher
+{
+  public:
+    size_t operator()(const std::string &key) const
+    {
+        std::string lower_copy = key;
+        std::transform(lower_copy.begin(), lower_copy.end(), lower_copy.begin(), ::tolower);
+        return inner_hasher_(lower_copy);
+    }
+
+  private:
+    std::hash<std::string> inner_hasher_;
+};
+
+class CaseInsensitiveStringComparator
+{
+  public:
+    bool operator()(const std::string &left, const std::string &right) const
+    {
+        return std::equal(left.begin(), left.end(), right.begin(), right.end(), CompareChars);
+    }
+
+  private:
+    static bool CompareChars(char a, char b)
+    {
+        return std::tolower(a) == std::tolower(b);
+    }
+};

--- a/src/libs/Common_h/strutils.h
+++ b/src/libs/Common_h/strutils.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <string>
 #include <algorithm>
+#include <string>
 
 namespace TOREMOVE
 {

--- a/src/libs/Common_h/strutils.h
+++ b/src/libs/Common_h/strutils.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <algorithm>
 #include <string>
 
 namespace TOREMOVE
@@ -27,32 +26,3 @@ inline void rtrim(std::string &str)
     }
 }
 } // namespace TOREMOVE
-
-class CaseInsensitiveStringHasher
-{
-  public:
-    size_t operator()(const std::string &key) const
-    {
-        std::string lower_copy = key;
-        std::transform(lower_copy.begin(), lower_copy.end(), lower_copy.begin(), ::tolower);
-        return inner_hasher_(lower_copy);
-    }
-
-  private:
-    std::hash<std::string> inner_hasher_;
-};
-
-class CaseInsensitiveStringComparator
-{
-  public:
-    bool operator()(const std::string &left, const std::string &right) const
-    {
-        return std::equal(left.begin(), left.end(), right.begin(), right.end(), CompareChars);
-    }
-
-  private:
-    static bool CompareChars(char a, char b)
-    {
-        return std::tolower(a) == std::tolower(b);
-    }
-};

--- a/src/libs/util/include/storm/string_compare.hpp
+++ b/src/libs/util/include/storm/string_compare.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <string>
 
 namespace storm
 {
@@ -31,21 +32,13 @@ template <typename Range1T, typename Range2T = Range1T> inline bool iEquals(cons
 {
     detail::is_iequal comp;
 
-    const auto end_input = std::end(first);
-    const auto end_test = std::end(second);
+    const auto first_begin = std::begin(first);
+    const auto second_begin = std::begin(second);
 
-    auto it_input = std::begin(first);
-    auto it_test = std::begin(second);
+    const auto first_end = std::end(first);
+    const auto second_end = std::end(second);
 
-    for (; it_input != end_input && it_test != end_test; ++it_input, ++it_test)
-    {
-        if (!comp(*it_input, *it_test))
-        {
-            return false;
-        }
-    }
-
-    return it_input == end_input && it_test == end_test;
+    return std::equal(first_begin, first_end, second_begin, second_end, comp);
 }
 
 template <typename Range1T, typename Range2T = Range1T> inline bool iLess(const Range1T &first, const Range2T &second)
@@ -146,5 +139,27 @@ inline int wildicmp(const char *wild, const char *string)
     }
     return !*wild;
 }
+
+class iStrHasher
+{
+  public:
+    size_t operator()(const std::string &key) const
+    {
+        std::string lower_copy = key;
+        std::transform(lower_copy.begin(), lower_copy.end(), lower_copy.begin(), ::tolower);
+        return inner_hasher_(lower_copy);
+    }
+
+  private:
+    std::hash<std::string> inner_hasher_;
+};
+
+struct iStrComparator
+{
+    bool operator()(const std::string &left, const std::string &right) const
+    {
+        return iEquals(left, right);
+    }
+};
 
 } // namespace storm


### PR DESCRIPTION
I replaced the "HASHLINE" in variables and function tables with std::unordered_map.

I rewrote both tables from scratch and I'm not sure if my naming code style was correct. I tried to conform to Google code style, because it was the most voted one.

Requires a small script change: in [this](https://github.com/storm-devs/sd-teho-public/blob/e7d161eb1d4da25a73a517ff6d8373d8acbb6609/program/characters/LSC_Q2Utilite.c#L1352) line a variable with an empty name is declared which normally should be a compile error. Just need to remove the comma and everything will compile correctly.