### PR TITLE
Do not draw best-course texture when texture is not set

### DIFF
--- a/src/libs/Battle_interface/sea/battle_navigator.cpp
+++ b/src/libs/Battle_interface/sea/battle_navigator.cpp
@@ -182,7 +182,7 @@ void BATTLE_NAVIGATOR::Draw() const
     }
 
     // show heading angles
-    if (m_idCourseVBuf != -1L)
+    if (m_idCourseVBuf != -1L && m_idBestCourseTex != -1L)
     {
         rs->TextureSet(0, m_idBestCourseTex);
         rs->DrawPrimitive(D3DPT_TRIANGLESTRIP, m_idCourseVBuf, sizeof(BI_ONETEXTURE_VERTEX), 0, 2, "battle_rectangle");


### PR DESCRIPTION
Fixes a small UI glitch in CoAS, which does not set a _best-course_ texture