### PR TITLE
Add support for old behavior of GetRiggingData

### DIFF
--- a/src/apps/ENGINE/Core.cpp
+++ b/src/apps/ENGINE/Core.cpp
@@ -275,7 +275,7 @@ void CORE::ProcessEngineIniFile()
             throw std::runtime_error("fail to run program");
 
         // Script version test
-        if (m_targetVersion >= storm::ENGINE_VERSION::LATEST)
+        if (targetVersion_ >= storm::ENGINE_VERSION::LATEST)
         {
             long iScriptVersion = 0xFFFFFFFF;
             auto *pVScriptVersion = static_cast<VDATA *>(core.GetScriptVariable("iScriptVersion"));
@@ -908,6 +908,11 @@ void *CORE::GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex)
     return real_var->value.get();
 }
 
+storm::ENGINE_VERSION CORE::GetTargetEngineVersion() const noexcept
+{
+    return targetVersion_;
+}
+
 void CORE::Start_CriticalSection()
 {
     EnterCriticalSection(&lock);
@@ -925,10 +930,10 @@ void CORE::loadCompatibilitySettings(INIFILE &inifile)
     inifile.ReadString("compatibility", "target_version", strBuffer.data(), strBuffer.size(), "latest");
     const std::string_view target_engine_version = strBuffer.data();
 
-    m_targetVersion = getTargetEngineVersion(target_engine_version);
-    if (m_targetVersion == ENGINE_VERSION::UNKNOWN)
+    targetVersion_ = getTargetEngineVersion(target_engine_version);
+    if (targetVersion_ == ENGINE_VERSION::UNKNOWN)
     {
         tracelog->warn("Unknown target version '{}' in engine compatibility settings", target_engine_version);
-        m_targetVersion = ENGINE_VERSION::LATEST;
+        targetVersion_ = ENGINE_VERSION::LATEST;
     }
 }

--- a/src/libs/Common_h/core.h
+++ b/src/libs/Common_h/core.h
@@ -155,10 +155,12 @@ class CORE
 
     void *GetScriptVariable(const char *pVariableName, uint32_t *pdwVarIndex = nullptr);
 
+    [[nodiscard]] storm::ENGINE_VERSION GetTargetEngineVersion() const noexcept;
+
   private:
     void loadCompatibilitySettings(INIFILE &inifile);
 
-    storm::ENGINE_VERSION m_targetVersion = storm::ENGINE_VERSION::LATEST;
+    storm::ENGINE_VERSION targetVersion_ = storm::ENGINE_VERSION::LATEST;
 };
 // core instance
 extern CORE core;

--- a/src/libs/Rigging/Flag.cpp
+++ b/src/libs/Rigging/Flag.cpp
@@ -868,7 +868,7 @@ void FLAG::SetAdd(int flagNum)
                 if (pvdat->IsArray())
                 {
                     pvdat->Get(curTexNumC, 0);
-                    pvdat->Get(curTexNumR, 0);
+                    pvdat->Get(curTexNumR, 1);
                 }
                 else
                 {

--- a/src/libs/Rigging/Flag.cpp
+++ b/src/libs/Rigging/Flag.cpp
@@ -601,8 +601,16 @@ void FLAG::LoadIni()
         memcpy(TextureName, param, len);
     }
 
-    FlagTextureQuantity = (int)ini->GetLong(section, "TextureCountColumn", 4);
-    FlagTextureQuantityRow = (int)ini->GetLong(section, "TextureCountRow", 8);
+    if (core.GetTargetEngineVersion() <= storm::ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS)
+    {
+        FlagTextureQuantity = static_cast<int>(ini->GetLong(section, "TextureCount", 10));
+        FlagTextureQuantityRow = 1;
+    }
+    else
+    {
+        FlagTextureQuantity = static_cast<int>(ini->GetLong(section, "TextureCountColumn", 4));
+        FlagTextureQuantityRow = static_cast<int>(ini->GetLong(section, "TextureCountRow", 8));
+    }
 
     SetTextureCoordinate();
 
@@ -829,30 +837,48 @@ void FLAG::SetAdd(int flagNum)
         {
             long curTexNumC = 0;
             long curTexNumR = 0;
+
             // set texture number
-            if (flist[fn]->isShip) // ship
+            if (core.GetTargetEngineVersion() <= storm::ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS)
             {
-                pvdat = core.Event("GetRiggingData", "sllla", "GetShipFlagTexNum", flist[fn]->triangle,
-                                   gdata[flist[fn]->HostGroup].nation, flist[fn]->isSpecialFlag,
-                                   gdata[flist[fn]->HostGroup].char_attributes);
+                pvdat = core.Event("GetRiggingData", "sll", "GetFlagTexNum", flist[fn]->triangle,
+                                   gdata[flist[fn]->HostGroup].nation);
             }
             else
             {
-                pvdat = core.Event("GetRiggingData", "slll", "GetTownFlagTexNum", flist[fn]->triangle,
-                                   gdata[flist[fn]->HostGroup].nation, flist[fn]->isSpecialFlag);
+                if (flist[fn]->isShip) // ship
+                {
+                    pvdat = core.Event("GetRiggingData", "sllla", "GetShipFlagTexNum", flist[fn]->triangle,
+                                       gdata[flist[fn]->HostGroup].nation, flist[fn]->isSpecialFlag,
+                                       gdata[flist[fn]->HostGroup].char_attributes);
+                }
+                else
+                {
+                    pvdat = core.Event("GetRiggingData", "slll", "GetTownFlagTexNum", flist[fn]->triangle,
+                                       gdata[flist[fn]->HostGroup].nation, flist[fn]->isSpecialFlag);
+                }
             }
             if (pvdat == nullptr)
             {
-                flist[fn]->texNumC = 0;
-                flist[fn]->texNumR = 0;
+                curTexNumC = 0;
+                curTexNumR = 0;
             }
             else
             {
-                pvdat->Get(curTexNumC, 0);
-                pvdat->Get(curTexNumR, 1);
-                flist[fn]->texNumC = curTexNumC;
-                flist[fn]->texNumR = curTexNumR;
+                if (pvdat->IsArray())
+                {
+                    pvdat->Get(curTexNumC, 0);
+                    pvdat->Get(curTexNumR, 0);
+                }
+                else
+                {
+                    pvdat->Get(curTexNumC);
+                    curTexNumR = 0;
+                }
             }
+
+            flist[fn]->texNumC = curTexNumC;
+            flist[fn]->texNumR = curTexNumR;
 
             flist[fn]->vectQuant = (int)(len / FLAGVECTORLEN); // number of flag segments
             if (flist[fn]->vectQuant < MinSegmentQuantity)


### PR DESCRIPTION
Fixes flags for CoAS

Since this is the first substantial backwards-compatibility change. I welcome any feedback or concerns about the approach taken.