### PR TITLE
Remove gunpowder icon from BattleInterface

### DIFF
--- a/src/libs/Battle_interface/sea/battle_navigator.cpp
+++ b/src/libs/Battle_interface/sea/battle_navigator.cpp
@@ -667,7 +667,7 @@ void BATTLE_NAVIGATOR::Init(VDX9RENDER *RenderService, Entity *pOwnerEI)
     m_idGradBackVBuf =
         rs->CreateVertexBuffer(BI_COLORONLY_VERTEX_FORMAT, 3 * sizeof(BI_COLORONLY_VERTEX), D3DUSAGE_WRITEONLY);
     m_idCurChargeVBuf =
-        rs->CreateVertexBuffer(BI_ONETEX_VERTEX_FORMAT, 4 * 4 * sizeof(BI_ONETEXTURE_VERTEX), D3DUSAGE_WRITEONLY);
+        rs->CreateVertexBuffer(BI_ONETEX_VERTEX_FORMAT, 3 * 4 * sizeof(BI_ONETEXTURE_VERTEX), D3DUSAGE_WRITEONLY);
     if (m_idEmptyVBuf == -1 || m_idCourseVBuf == -1 || m_idCannonVBuf == -1 || m_idSpeedVBuf == -1 ||
         m_idMapVBuf == -1 || m_idFireZoneVBuf == -1 || m_idShipsVBuf == -1 || m_idGradBackVBuf == -1 ||
         m_idCurChargeVBuf == -1)
@@ -788,7 +788,7 @@ void BATTLE_NAVIGATOR::Init(VDX9RENDER *RenderService, Entity *pOwnerEI)
     pV = static_cast<BI_ONETEXTURE_VERTEX *>(rs->LockVertexBuffer(m_idCurChargeVBuf));
     if (pV != nullptr)
     {
-        for (i = 0; i < 4 * 4; i++)
+        for (i = 0; i < 3 * 4; i++)
         {
             pV[i].pos.z = 1.f;
             pV[i].w = .5f;

--- a/src/libs/Battle_interface/sea/battle_navigator.h
+++ b/src/libs/Battle_interface/sea/battle_navigator.h
@@ -158,7 +158,6 @@ class BATTLE_NAVIGATOR
     long m_idWindTex;       // wind
     long m_idBestCourseTex; // best direction pointers
     long m_idChargeTexture; // current cannon charge type
-    long m_idPowderTexture; // current gunpowder
     long m_idWindTexture;   // wind speed
     long m_idSailTexture;   // sail position / ship speed
     IDirect3DTexture9 *m_pIslandTexture;
@@ -206,12 +205,6 @@ class BATTLE_NAVIGATOR
     POINT m_ChargePos;
     POINT m_ChargeSize;
     long m_curCharge;
-    // gunpowder icon
-    POINT m_PowderGreed;
-    POINT m_PowderPos;
-    POINT m_PowderSize;
-    long m_curPowder;
-    bool m_bPowderRunOut; // for blinking
     // wind icon
     long m_curWindPic;
     POINT m_WindGreed;


### PR DESCRIPTION
Because there is no code for this texture in scripts, there was a white rectangle in the battle interface.