### PR TITLE
[CoaS] Fix crash when opening Index of Terms in QuestBook on ru-locale

### DIFF
--- a/src/libs/Xinterface/QuestFileReader/QuestFileReader.cpp
+++ b/src/libs/Xinterface/QuestFileReader/QuestFileReader.cpp
@@ -307,7 +307,9 @@ void QUEST_FILE_READER::GetRecordTextList(std::vector<std::string> &asStringList
     m_aQuestData.clear();
     FillUserDataList((char *)pcUserData, m_aQuestData);
 
-    char pcTmp[10240]; // boal 4096
+    /// @note If text is larger than the buffer size it can result to discarding some bytes of multibyte utf-8 symbol
+    /// that results to -1 when calling utf8::Utf8ToCodepoint on that symbol
+    char pcTmp[20480];
     AssembleStringToBuffer(m_aQuest[nQuestIndex].aText[nTextIndex].str.c_str(),
                            m_aQuest[nQuestIndex].aText[nTextIndex].str.size(), pcTmp, sizeof(pcTmp), m_aQuestData);
     asStringList.push_back(pcTmp);


### PR DESCRIPTION
Backward compatibility for CoaS. Some texts in russian do not fit to the buffer that results in breaking multibyte utf symbol and crash when trying to read that symbol.

A better way to fix this is to rewrite questbook functions (and all XInterface lib) to use more high-level approach to work with strings (without raw buffers and etc.). But that needs much more time, so i decided to provide quickfix just for now.