### PR TITLE
Make date output optional for `MSG_INTERFACE_GETTIME`

### DIFF
--- a/src/libs/xinterface/src/xinterface.cpp
+++ b/src/libs/xinterface/src/xinterface.cpp
@@ -1009,11 +1009,15 @@ uint64_t XINTERFACE::ProcessMessage(MESSAGE &message)
         {
             pvdat->Set(param2);
         }
-        std::strftime(param2, sizeof(param2), "%d.%m.%Y", locTime);
-        pvdat = message.ScriptVariablePointer();
-        if (pvdat)
+
+        if (message.GetFormat() == "lsee") 
         {
-            pvdat->Set(param2);
+            std::strftime(param2, sizeof(param2), "%d.%m.%Y", locTime);
+            pvdat = message.ScriptVariablePointer();
+            if (pvdat)
+            {
+                pvdat->Set(param2);
+            }
         }
     }
     break;


### PR DESCRIPTION
Makes the date part optional