### PR TITLE
Fix crash when string attribute in BI is not exists

### DIFF
--- a/src/libs/battle_interface/src/land/battle_mansign.h
+++ b/src/libs/battle_interface/src/land/battle_mansign.h
@@ -163,7 +163,7 @@ inline bool BIManSign::FloatACompare(ATTRIBUTES *pA, const char *attrName, float
 inline bool BIManSign::StringACompare(ATTRIBUTES *pA, const char *attrName, std::string &sCompareVal)
 {
     auto *const pVal = pA->GetAttribute(attrName);
-    if (sCompareVal == pVal)
+    if (pVal == nullptr || sCompareVal == pVal)
         return false;
     sCompareVal = pVal;
     return true;


### PR DESCRIPTION
Comparing std::string with nullptr results to crash