### PR TITLE
fix handling _GetExecutableDirectory return value

### DIFF
--- a/src/libs/diagnostics/src/LifecycleDiagnosticsService.cpp
+++ b/src/libs/diagnostics/src/LifecycleDiagnosticsService.cpp
@@ -134,7 +134,7 @@ LifecycleDiagnosticsService::Guard LifecycleDiagnosticsService::initialize(const
     if (!initialized_)
     {
         // TODO: make this crossplatform
-        const auto executableDir = std::filesystem::path{fio->_GetExecutableDirectory()};
+        const auto executableDir = std::filesystem::path{std::filesystem::u8path(fio->_GetExecutableDirectory())};
         const auto logsArchive = fs::GetLogsPath().replace_extension(".7z");
         constexpr auto archiverBin = "7za.exe";
 

--- a/src/libs/renderer/src/sdevice.cpp
+++ b/src/libs/renderer/src/sdevice.cpp
@@ -2444,7 +2444,7 @@ void DX9RENDER::RecompileEffects()
     effects_.release();
 
     std::filesystem::path cur_path = std::filesystem::current_path();
-    std::filesystem::current_path(fio->_GetExecutableDirectory());
+    std::filesystem::current_path(std::filesystem::u8path(fio->_GetExecutableDirectory()));
     for (const auto &p : std::filesystem::recursive_directory_iterator("resource/techniques"))
         if (is_regular_file(p) && p.path().extension() == ".fx")
         {


### PR DESCRIPTION
_GetExecutableDirectory uses SDL_GetBasePath that returns utf-8 path. 
That is not preserved in two places leading to crashes if the engine or documents folders contains non-locale symbols in their path