### PR TITLE
renderer: increase max buffers amount

### DIFF
--- a/src/libs/renderer/src/sdevice.h
+++ b/src/libs/renderer/src/sdevice.h
@@ -13,8 +13,8 @@
 #include <stack>
 #include <vector>
 
-#define MAX_STEXTURES 1024
-#define MAX_BUFFERS 1024
+#define MAX_STEXTURES 10240
+#define MAX_BUFFERS 10240
 #define MAX_FONTS 256
 
 struct D3DERRORS


### PR DESCRIPTION
This is to be completely rewritten, but for now, let's just increase the buffers because 1024 is too low (10+ ships on the sea with enabled foam cause overflow)