### PR TITLE
Remove character in location limit

### DIFF
--- a/src/libs/location/src/Character.cpp
+++ b/src/libs/location/src/Character.cpp
@@ -1808,13 +1808,12 @@ void Character::Dead()
     Assert(dead);
     // spread weights depending on the direction
     const float _ay = ay;
-    static Supervisor::FindCharacter fnd[MAX_CHARACTERS];
-    static long numChr = 0;
     auto *const location = GetLocation();
     for (long i = 0; i < num; i++)
     {
         ay = _ay + dead[i].ang;
-        if (location->supervisor.FindCharacters(fnd, numChr, this, 2.0f, 0.0f, 0.0f))
+        auto fnd = location->supervisor.FindCharacters(this, 2.0f, 0.0f, 0.0f);
+        if (!fnd.empty())
             dead[i].p *= 0.1f;
         const float cs = cosf(dead[i].ang);
         const float sn = sinf(dead[i].ang);
@@ -4641,14 +4640,13 @@ Character *Character::FindDialogCharacter()
     if (IsFight() || liveValue < 0 || deadName)
         return nullptr;
     // Find the surrounding characters
-    static Supervisor::FindCharacter fndCharacter[MAX_CHARACTERS];
-    static long num = 0;
-    if (!location->supervisor.FindCharacters(fndCharacter, num, this, 3.0f))
+    auto fndCharacter = location->supervisor.FindCharacters(this, 3.0f);
+    if (fndCharacter.empty())
         return nullptr;
     // Choosing the best
     float minDst;
     long j = -1;
-    for (long i = 0; i < num; i++)
+    for (size_t i = 0; i < fndCharacter.size(); i++)
     {
         // Character
         Supervisor::FindCharacter &fc = fndCharacter[i];
@@ -4766,16 +4764,16 @@ inline void Character::CheckAttackHit()
         }
     }
     // Find the surrounding characters
-    static Supervisor::FindCharacter fndCharacter[MAX_CHARACTERS];
-    long num = 0;
     auto *const location = GetLocation();
-    if (!location->supervisor.FindCharacters(fndCharacter, num, this, attackDist, attackAng, 0.1f, 0.0f, false, true))
+    auto fndCharacter =
+        location->supervisor.FindCharacters(this, attackDist, attackAng, 0.1f, 0.0f, false, true);
+    if (fndCharacter.empty())
         return;
     // go through all the enemies
     bool isParry = false;
     bool isHrrrSound = true;
     bool isUseEnergy = true; // remove energy once boal
-    for (long i = 0; i < num; i++)
+    for (size_t i = 0; i < fndCharacter.size(); i++)
     {
         // Character
         Supervisor::FindCharacter &fc = fndCharacter[i];
@@ -4857,15 +4855,14 @@ Character *Character::FindGunTarget(float &kDist, bool bOnlyEnemyTest, bool bAbo
     }
 
     // Find the surrounding characters
-    static Supervisor::FindCharacter fndCharacter[MAX_CHARACTERS];
-    static long num = 0;
     auto *const location = GetLocation();
-    if (!location->supervisor.FindCharacters(fndCharacter, num, this, CHARACTER_FIGHT_FIREDIST, CHARACTER_FIGHT_FIREANG,
-                                             0.4f, 30.0f, false))
+    auto fndCharacter = location->supervisor.FindCharacters(this, CHARACTER_FIGHT_FIREDIST, CHARACTER_FIGHT_FIREANG,
+                                                            0.4f, 30.0f, false);
+    if (fndCharacter.empty())
         return nullptr;
     float minDst;
     long j = -1;
-    for (long i = 0; i < num; i++)
+    for (size_t i = 0; i < fndCharacter.size(); i++)
     {
         Supervisor::FindCharacter &fc = fndCharacter[i];
         if (fc.d2 <= 0.0f || fc.c->radius <= 0.0f)
@@ -4935,10 +4932,10 @@ void Character::FindNearCharacters(MESSAGE &message)
     const bool isSort = message.Long() != 0;
     // Looking for characters
     // Find the surrounding characters
-    static Supervisor::FindCharacter fndCharacter[MAX_CHARACTERS];
-    static long n = 0;
     auto *const location = GetLocation();
-    if (!location->supervisor.FindCharacters(fndCharacter, n, this, rad, viewAng, planeDist, ax, isSort))
+    auto fndCharacter = location->supervisor.FindCharacters(this, rad, viewAng, planeDist, ax, isSort);
+    auto n = fndCharacter.size();
+    if (fndCharacter.empty())
     {
         num->Set(0L);
         return;

--- a/src/libs/location/src/Character.cpp
+++ b/src/libs/location/src/Character.cpp
@@ -661,11 +661,6 @@ bool Character::Init()
     effects = EntityManager::GetEntityId("LocationEffects");
     soundService = static_cast<VSoundService *>(core.CreateService("SoundService"));
     // register our appearance in the location
-    if (location->supervisor.numCharacters >= MAX_CHARACTERS)
-    {
-        core.Trace("Many characters in location");
-        return false;
-    }
     location->supervisor.AddCharacter(this);
     // The sea
     sea = EntityManager::GetEntityId("sea");

--- a/src/libs/location/src/CharactersGroups.cpp
+++ b/src/libs/location/src/CharactersGroups.cpp
@@ -236,25 +236,26 @@ void CharactersGroups::CharacterVisibleCheck(Character *chr)
         return;
     auto *const grp = groups[gi];
     // Visible area
-    long num;
-    if (location->supervisor.FindCharacters(fnd, num, chr, grp->look, CGS_VIEWANGLE, 0.05f))
+    fnd = location->supervisor.FindCharacters(chr, grp->look, CGS_VIEWANGLE, 0.05f);
+    if (!fnd.empty())
     {
-        FindEnemyFromFindList(chr, grp, num, true);
+        FindEnemyFromFindList(chr, grp, true);
     }
     // Audible area
-    if (location->supervisor.FindCharacters(fnd, num, chr, grp->hear))
+    fnd = location->supervisor.FindCharacters(chr, grp->hear);
+    if (!fnd.empty())
     {
-        FindEnemyFromFindList(chr, grp, num, false);
+        FindEnemyFromFindList(chr, grp, false);
     }
 }
 
 // Check found characters for enemies
-void CharactersGroups::FindEnemyFromFindList(Character *chr, Group *grp, long num, bool visCheck)
+void CharactersGroups::FindEnemyFromFindList(Character *chr, Group *grp, bool visCheck)
 {
     Character *targets[MAX_CHARACTERS];
     long numTrg = 0;
     // For all found characters
-    for (long i = 0; i < num; i++)
+    for (size_t i = 0; i < fnd.size(); i++)
     {
         // Found character group
         const auto gi = GetCharacterGroup(fnd[i].c);
@@ -274,9 +275,9 @@ void CharactersGroups::FindEnemyFromFindList(Character *chr, Group *grp, long nu
         }
     }
     // Inform others about the detected targets
-    if (numTrg > 0 && location->supervisor.FindCharacters(fnd, num, chr, grp->say))
+    if (numTrg > 0 && !(fnd = location->supervisor.FindCharacters(chr, grp->say)).empty())
     {
-        for (long i = 0; i < num; i++)
+        for (size_t i = 0; i < fnd.size(); i++)
         {
             auto *const c = fnd[i].c;
             // If invisible, then skip it
@@ -700,10 +701,10 @@ void CharactersGroups::MsgAddTarget(MESSAGE &message)
     // Adding the enemy
     AddEnemyTarget(chr, enemy, message.Float());
     // Informing others about the new goal
-    long num = 0;
-    if (location->supervisor.FindCharacters(fnd, num, chr, groups[g1]->say))
+    fnd = location->supervisor.FindCharacters(chr, groups[g1]->say);
+    if (!fnd.empty())
     {
-        for (long i = 0; i < num; i++)
+        for (size_t i = 0; i < fnd.size(); i++)
         {
             auto *const c = fnd[i].c;
             // If invisible, then skip it

--- a/src/libs/location/src/CharactersGroups.cpp
+++ b/src/libs/location/src/CharactersGroups.cpp
@@ -252,8 +252,7 @@ void CharactersGroups::CharacterVisibleCheck(Character *chr)
 // Check found characters for enemies
 void CharactersGroups::FindEnemyFromFindList(Character *chr, Group *grp, bool visCheck)
 {
-    Character *targets[MAX_CHARACTERS];
-    long numTrg = 0;
+    std::vector<Character *> targets;
     // For all found characters
     for (size_t i = 0; i < fnd.size(); i++)
     {
@@ -270,12 +269,11 @@ void CharactersGroups::FindEnemyFromFindList(Character *chr, Group *grp, bool vi
         // Found an enemy, add
         if (AddEnemyTarget(chr, fnd[i].c))
         {
-            if (numTrg < MAX_CHARACTERS)
-                targets[numTrg++] = fnd[i].c;
+            targets.push_back(fnd[i].c);
         }
     }
     // Inform others about the detected targets
-    if (numTrg > 0 && !(fnd = location->supervisor.FindCharacters(chr, grp->say)).empty())
+    if (!targets.empty() && !(fnd = location->supervisor.FindCharacters(chr, grp->say)).empty())
     {
         for (size_t i = 0; i < fnd.size(); i++)
         {
@@ -291,7 +289,7 @@ void CharactersGroups::FindEnemyFromFindList(Character *chr, Group *grp, bool vi
             auto &r = FindRelation(grp->index, cgrp);
             if (r.curState != rs_friend)
                 continue;
-            for (long j = 0; j < numTrg; j++)
+            for (size_t j = 0; j < targets.size(); j++)
             {
                 if (grp->index != cgrp)
                 {

--- a/src/libs/location/src/CharactersGroups.cpp
+++ b/src/libs/location/src/CharactersGroups.cpp
@@ -204,7 +204,7 @@ void CharactersGroups::Execute(uint32_t delta_time)
     waveTime += dltTime;
     if (curExecuteChr >= 0)
     {
-        if (curExecuteChr < location->supervisor.numCharacters)
+        if (curExecuteChr < location->supervisor.character.size())
         {
             auto *const c = location->supervisor.character[curExecuteChr].c;
             CharacterVisibleCheck(c);
@@ -356,7 +356,7 @@ bool CharactersGroups::AddEnemyTarget(Character *chr, Character *enemy, float ma
 void CharactersGroups::RemoveAllInvalidTargets()
 {
     // Update goal lists
-    for (long i = 0; i < location->supervisor.numCharacters; i++)
+    for (size_t i = 0; i < location->supervisor.character.size(); i++)
     {
         RemoveInvalidTargets(location->supervisor.character[i].c);
     }
@@ -570,8 +570,8 @@ bool CharactersGroups::MsgGetOptimalTarget(MESSAGE &message) const
     {
         CVECTOR pos, p;
         c->GetPosition(pos);
-        const auto numChr = location->supervisor.numCharacters;
-        auto *const cEx = location->supervisor.character;
+        const auto numChr = location->supervisor.character.size();
+        auto &cEx = location->supervisor.character;
         // choose the optimal goal
         float value;
         s = -1;
@@ -1180,7 +1180,7 @@ long CharactersGroups::GetCharacterGroup(Character *c)
 void CharactersGroups::ClearAllTargets() const
 {
     // Update goal lists
-    for (long i = 0; i < location->supervisor.numCharacters; i++)
+    for (size_t i = 0; i < location->supervisor.character.size(); i++)
     {
         location->supervisor.character[i].c->numTargets = 0;
     }

--- a/src/libs/location/src/CharactersGroups.h
+++ b/src/libs/location/src/CharactersGroups.h
@@ -73,8 +73,7 @@ class CharactersGroups : public Entity
         float say;                 // The radius at which the character can inform neighbors about the danger
         long priority;             // Protection priority
         Relation *relations;       // Relationship list - the size corresponds to the group index in the list
-        entid_t c[MAX_CHARACTERS]; // List of characters in the group
-        long numChr;               // Number of characters in the group
+        std::vector<entid_t> c;    // List of characters in the group
     };
 
     // --------------------------------------------------------------------------------------------

--- a/src/libs/location/src/CharactersGroups.h
+++ b/src/libs/location/src/CharactersGroups.h
@@ -116,7 +116,7 @@ class CharactersGroups : public Entity
     // Checking the character detects others
     void CharacterVisibleCheck(Character *chr);
     // Check found characters for enemies
-    void FindEnemyFromFindList(Character *chr, Group *grp, long num, bool visCheck);
+    void FindEnemyFromFindList(Character *chr, Group *grp, bool visCheck);
     // Add or update an enemy
     bool AddEnemyTarget(Character *chr, Character *enemy, float maxtime = -1.0);
     // Remove all inactive or invalid targets
@@ -214,5 +214,5 @@ class CharactersGroups : public Entity
     float waveTime;              // Time since last wave launch
 
     // Character search array
-    Supervisor::FindCharacter fnd[MAX_CHARACTERS];
+    std::vector<Supervisor::FindCharacter> fnd;
 };

--- a/src/libs/location/src/Grass.cpp
+++ b/src/libs/location/src/Grass.cpp
@@ -54,7 +54,6 @@ Grass::Grass()
     lodSelect = GRASS_BLK_LOD;
     winForce = 0.3f;
     winDir = !CVECTOR(0.0f, 0.0f, 1.0f);
-    numCharacters = 0;
 
     strcpy_s(textureName, GRASS_DEFTEXTURE);
 
@@ -617,7 +616,7 @@ void Grass::Realize(uint32_t delta_time)
 
     rs->SetRenderState(D3DRS_FOGDENSITY, dwOldFogDensity);
 
-    for (long i = 0; i < numCharacters; i++)
+    for (size_t i = 0; i < characters.size(); i++)
     {
         if (characters[i].useCounter > 2)
         {
@@ -694,8 +693,8 @@ void Grass::RenderBlock(const CVECTOR &camPos, const PLANE *plane, long numPlane
     if (kLod < m_fMinGrassLod)
         kLod = m_fMinGrassLod;
     // Determine the characters that fall into the current block
-    numBlockChr = 0;
-    for (long i = 0; i < numCharacters; i++)
+    blockChrs.clear();
+    for (size_t i = 0; i < characters.size(); i++)
     {
         // skip falling out characters
         if (characters[i].pos.x + 0.9f < min.x)
@@ -711,7 +710,7 @@ void Grass::RenderBlock(const CVECTOR &camPos, const PLANE *plane, long numPlane
         if (characters[i].pos.z - 0.9f > max.z)
             continue;
         // Add an index
-        blockChrs[numBlockChr++] = i;
+        blockChrs.push_back(i);
     }
     // Render block
     RenderBlock(mm, kLod);
@@ -831,7 +830,7 @@ inline void Grass::RenderBlock(GRSMiniMapElement &mme, float kLod)
             winx = (0.9f * winx + kwDirX) * kamp + wAddX;
             winz = (0.9f * winz + kwDirZ) * kamp + wAddZ;
             // take into account the characters
-            for (long chr = 0; chr < numBlockChr; chr++)
+            for (size_t chr = 0; chr < blockChrs.size(); chr++)
             {
                 CharacterPos &cp = characters[blockChrs[chr]];
                 if (fabsf(cp.pos.y - y) < 0.7f)

--- a/src/libs/location/src/Grass.h
+++ b/src/libs/location/src/Grass.h
@@ -145,8 +145,7 @@ class Grass : public Entity
     // Set texture
     void SetTexture(const char *texName);
 
-    CharacterPos characters[MAX_CHARACTERS];
-    long numCharacters;
+    std::vector<CharacterPos> characters;
 
     // --------------------------------------------------------------------------------------------
     // Encapsulation
@@ -192,8 +191,7 @@ class Grass : public Entity
     CVECTOR lColor; // Source color
     CVECTOR aColor; // Ambient light color
 
-    long blockChrs[32]; // Indexes of characters processed by the block
-    long numBlockChr;   // Number of characters processed by the block
+    std::vector<long> blockChrs; // Indexes of characters processed by the block
 
     float lodSelect; // Lod selection range factor (kLod = kLod^lodSelect)
     float winForce;  // Wind speed coefficient 0..1

--- a/src/libs/location/src/Location.cpp
+++ b/src/libs/location/src/Location.cpp
@@ -125,13 +125,13 @@ void Location::Execute(uint32_t delta_time)
     auto *grs = static_cast<Grass *>(EntityManager::GetEntityPointer(grass));
     if (grs)
     {
+        grs->characters.resize(supervisor.character.size());
         for (size_t i = 0; i < supervisor.character.size(); i++)
         {
             supervisor.character[i].c->GetGrassPosition(grs->characters[i].pos, grs->characters[i].lastPos);
             grs->characters[i].chr = supervisor.character[i].c;
             grs->characters[i].useCounter = 0;
         }
-        grs->numCharacters = supervisor.character.size();
     }
     // Location update
     locationTimeUpdate += dltTime;

--- a/src/libs/location/src/Location.cpp
+++ b/src/libs/location/src/Location.cpp
@@ -125,13 +125,13 @@ void Location::Execute(uint32_t delta_time)
     auto *grs = static_cast<Grass *>(EntityManager::GetEntityPointer(grass));
     if (grs)
     {
-        for (long i = 0; i < supervisor.numCharacters; i++)
+        for (size_t i = 0; i < supervisor.character.size(); i++)
         {
             supervisor.character[i].c->GetGrassPosition(grs->characters[i].pos, grs->characters[i].lastPos);
             grs->characters[i].chr = supervisor.character[i].c;
             grs->characters[i].useCounter = 0;
         }
-        grs->numCharacters = supervisor.numCharacters;
+        grs->numCharacters = supervisor.character.size();
     }
     // Location update
     locationTimeUpdate += dltTime;

--- a/src/libs/location/src/NPCharacter.cpp
+++ b/src/libs/location/src/NPCharacter.cpp
@@ -862,12 +862,9 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
         return;
     }
     // collect everyone around
-    static Supervisor::FindCharacter fndCharacter[MAX_CHARACTERS];
-    static long num = 0;
     auto *const location = GetLocation();
-    if (!location->supervisor.FindCharacters(fndCharacter, num, this, CHARACTER_ATTACK_DIST, 0.0f, 0.01f, 0.0f, false))
-        return;
-    if (!num)
+    auto fndCharacter = location->supervisor.FindCharacters(this, CHARACTER_ATTACK_DIST, 0.0f, 0.01f, 0.0f, false);
+    if (fndCharacter.empty())
         return;
     // our group
     const long grpIndex = chrGroup->FindGroupIndex(group);
@@ -879,7 +876,7 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
     // Calculating enemies
     bool isFreeBack = isRecoilEnable;
     static const float backAng = -cosf(45.0f * (3.1415926535f / 180.0f));
-    for (long i = 0; i < num; i++)
+    for (size_t i = 0; i < fndCharacter.size(); i++)
     {
         // Character
         Supervisor::FindCharacter &fc = fndCharacter[i];

--- a/src/libs/location/src/NPCharacter.cpp
+++ b/src/libs/location/src/NPCharacter.cpp
@@ -869,8 +869,7 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
     // our group
     const long grpIndex = chrGroup->FindGroupIndex(group);
     // Enemy table
-    static EnemyState enemies[MAX_CHARACTERS];
-    long enemyCounter = 0;
+    auto enemies = std::vector<EnemyState>();
     // Our direction
     const CVECTOR dir(sinf(ay), 0.0f, cosf(ay));
     // Calculating enemies
@@ -904,17 +903,18 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
         if (chrGroup->FindRelation(grpIndex, grp).curState != CharactersGroups::rs_enemy)
             continue;
         // This is the enemy
-        enemies[enemyCounter].chr = chr;
+        auto &found_enemy = enemies.emplace_back();
+        found_enemy.chr = chr;
         // Where the enemy is looking and location relative to us
         if (fc.d2 > 0.0f)
         {
-            enemies[enemyCounter].look = -(sinf(chr->ay) * fc.dx + cosf(chr->ay) * fc.dz) / fc.d2;
-            enemies[enemyCounter].dir = (dir.x * fc.dx + dir.z * fc.dz) / fc.d2;
+            found_enemy.look = -(sinf(chr->ay) * fc.dx + cosf(chr->ay) * fc.dz) / fc.d2;
+            found_enemy.dir = (dir.x * fc.dx + dir.z * fc.dz) / fc.d2;
         }
         else
         {
-            enemies[enemyCounter].look = 0.0f;
-            enemies[enemyCounter].dir = 0.0f;
+            found_enemy.look = 0.0f;
+            found_enemy.dir = 0.0f;
         }
         // If necessary, analyze the goal
         if (wishAttact)
@@ -935,12 +935,11 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
                 energy = 0.0f;
             if (energy > 1.0f)
                 energy = 1.0f;
-            enemies[enemyCounter].state = 0.1f / (hp + 0.05f) + 0.2f / (energy + 0.5f);
+            found_enemy.state = 0.1f / (hp + 0.05f) + 0.2f / (energy + 0.5f);
         }
-        enemyCounter++;
     }
     // If there is no one malicious, do nothing
-    if (!enemyCounter)
+    if (enemies.empty())
         return;
     // If attack, then choose a suitable target for the attack.
     if (wishAttact)
@@ -948,7 +947,7 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
         float kSel;
         long counter = 0;
         Character *enemy = nullptr;
-        for (long i = 0, j = -1; i < enemyCounter; i++)
+        for (size_t i = 0; i < enemies.size(); i++)
         {
             EnemyState &es = enemies[i];
             const float k = es.state * 1.0f + (es.dir + 1.0f) * 0.5f;
@@ -978,7 +977,7 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
     bool isBreakAttack = false;
     long attacked = 0;
     static const float attackAng = cosf(0.5f * CHARACTER_ATTACK_ANG * (3.1415926535f / 180.0f));
-    for (long i = 0; i < enemyCounter; i++)
+    for (size_t i = 0; i < enemies.size(); i++)
     {
         if (enemies[i].look >= attackAng)
         {
@@ -1026,7 +1025,7 @@ void NPCharacter::DoFightActionAnalysisNone(float dltTime, NPCharacter *enemy)
             else
             {
                 // There is a choice - parry or bounce
-                if (PrTest(0.4f + enemyCounter * (0.1f + fightLevel * 0.1f)))
+                if (PrTest(0.4f + enemies.size() * (0.1f + fightLevel * 0.1f)))
                 {
                     Recoil();
                 }

--- a/src/libs/location/src/Player.cpp
+++ b/src/libs/location/src/Player.cpp
@@ -632,9 +632,8 @@ Player *Player::FindAttackCharacter()
 {
     auto *const location = GetLocation();
     // Find the surrounding characters
-    static Supervisor::FindCharacter fndCharacter[MAX_CHARACTERS];
-    static long num = 0;
-    if (!location->supervisor.FindCharacters(fndCharacter, num, this, CHARACTER_ATTACK_DIST * 1.1f))
+    auto fndCharacter = location->supervisor.FindCharacters(this, CHARACTER_ATTACK_DIST * 1.1f);
+    if (fndCharacter.empty())
         return nullptr;
     // Choosing the best
     float minDst;
@@ -645,7 +644,7 @@ Player *Player::FindAttackCharacter()
     const auto cdx = sinf(ay);
     const auto cdz = cosf(ay);
     long j = -1;
-    for (long i = 0; i < num; i++)
+    for (size_t i = 0; i < fndCharacter.size(); i++)
     {
         // Character
         auto &fc = fndCharacter[i];

--- a/src/libs/location/src/Player.cpp
+++ b/src/libs/location/src/Player.cpp
@@ -309,7 +309,7 @@ void Player::Update(float dltTime)
     if (const auto eid = EntityManager::GetEntityId("CharactersGroups"))
     {
         auto *const location = GetLocation();
-        for (long i = 0; i < location->supervisor.numCharacters; i++)
+        for (size_t i = 0; i < location->supervisor.character.size(); i++)
         {
             auto *const chr = location->supervisor.character[i].c;
             if (chr != this && chr)
@@ -770,8 +770,9 @@ void Player::FireFromShootgun()
                 auto *const e = EntityManager::GetEntityPointer(collide->GetObjectID());
                 if (e && e != this)
                 {
-                    long n, nm;
-                    for (n = 0, nm = location->supervisor.numCharacters; n < nm; n++)
+                    long nm;
+                    size_t n;
+                    for (n = 0, nm = location->supervisor.character.size(); n < nm; n++)
                     {
                         auto *c = static_cast<Player *>(location->supervisor.character[n].c);
                         if (c->Model() == e)

--- a/src/libs/location/src/Supervisor.h
+++ b/src/libs/location/src/Supervisor.h
@@ -82,10 +82,8 @@ class Supervisor
     long curUpdate;
 
   public:
-    CharacterEx character[MAX_CHARACTERS];
-    long numCharacters;
-    CharacterInfo colchr[MAX_CHARACTERS * MAX_CHARACTERS];
-    long numColChr;
+    std::vector<CharacterEx> character;
+    std::vector<CharacterInfo> colchr;
     bool isDelete;
     Character *player;
 };

--- a/src/libs/location/src/Supervisor.h
+++ b/src/libs/location/src/Supervisor.h
@@ -15,8 +15,6 @@ class Character;
 class LocatorArray;
 struct CVECTOR;
 
-#define MAX_CHARACTERS 64
-
 class Supervisor
 {
     friend Character;

--- a/src/libs/location/src/Supervisor.h
+++ b/src/libs/location/src/Supervisor.h
@@ -9,6 +9,7 @@
 // ============================================================================================
 
 #pragma once
+#include <vector>
 
 class Character;
 class LocatorArray;
@@ -33,8 +34,6 @@ class Supervisor
         Character *c;     // The character we were looking for
         float dx, dy, dz; // Vector from the character to us
         float d2;         // The square of the distance to the character in xz
-        float l, r, n;    // Distance to clipping planes (optional)
-        float sectDist;   // Distance to the sector
     };
 
     struct CharacterEx
@@ -53,9 +52,10 @@ class Supervisor
     // Check for free position
     bool CheckPosition(float x, float y, float z, Character *c) const;
     // Find characters by radius
-    bool FindCharacters(FindCharacter fndCharacter[MAX_CHARACTERS], long &numFndCharacters, Character *chr,
-                        float radius, float angTest = 0.0f, float nearPlane = 0.4f, float ax = 0.0f,
-                        bool isSort = false, bool lookCenter = false) const;
+    std::vector<FindCharacter> FindCharacters(Character *chr,
+                                              float radius, float angTest = 0.0f, float nearPlane = 0.4f,
+                                              float ax = 0.0f,
+                                              bool isSort = false, bool lookCenter = false) const;
 
     void Update(float dltTime);
     void PreUpdate(float dltTime) const;


### PR DESCRIPTION
By changing static arrays to vectors I removed the engine's limit of 64 characters per location. Scripts have their own limit in form of ``#define MAX_CHARS_IN_LOC	64``, but this can be changed to any value, 128 for example, or the scripts could be rewritten to remove any limits whatsoever.