### PR TITLE
animation,blade,model: implement manual AVX/SSE2 vectorization for model animation blending

### DIFF
--- a/src/libs/animation/src/AnimationImp.cpp
+++ b/src/libs/animation/src/AnimationImp.cpp
@@ -330,6 +330,11 @@ void AnimationImp::BuildAnimationMatrices()
     {
         auto &bn = aniInfo->GetBone(j);
         matrix[j] = CMatrix(bn.start) * CMatrix(bn.matrix);
+        // inverse first column in advance
+        matrix[j].matrix[0] = -matrix[j].matrix[0];
+        matrix[j].matrix[4] = -matrix[j].matrix[4];
+        matrix[j].matrix[8] = -matrix[j].matrix[8];
+        matrix[j].matrix[12] = -matrix[j].matrix[12];
     }
 }
 

--- a/src/libs/blade/src/blade.cpp
+++ b/src/libs/blade/src/blade.cpp
@@ -78,11 +78,6 @@ void BLADE::BLADE_INFO::DrawBlade(VDX9RENDER *rs, unsigned int blendValue, MODEL
             mt.Pos() = CVECTOR(lb.m[3][0], lb.m[3][1], lb.m[3][2]);
 
             auto mbn = mt * bones[lb.bones[0]];
-            mbn.Pos().x *= -1.0f;
-            mbn.Vx().x *= -1.0f;
-            mbn.Vy().x *= -1.0f;
-            mbn.Vz().x *= -1.0f;
-
             CMatrix scl;
             scl.Vx().x = -1.0f;
             scl.Vy().y = 1.0f;
@@ -296,11 +291,6 @@ void BLADE::Realize(uint32_t Delta_Time)
             mt.Pos() = CVECTOR(lb.m[3][0], lb.m[3][1], lb.m[3][2]);
 
             auto mbn = mt * bones[lb.bones[0]];
-            mbn.Pos().x *= -1.0f;
-            mbn.Vx().x *= -1.0f;
-            mbn.Vy().x *= -1.0f;
-            mbn.Vz().x *= -1.0f;
-
             CMatrix scl;
             scl.Vx().x = -1.0f;
             scl.Vy().y = 1.0f;
@@ -412,10 +402,6 @@ void BLADE::GunFire()
             mt.Pos() = CVECTOR(lb.m[3][0], lb.m[3][1], lb.m[3][2]);
 
             auto mbn = mt * bones[lb.bones[0]];
-            mbn.Pos().x *= -1.0f;
-            mbn.Vx().x *= -1.0f;
-            mbn.Vy().x *= -1.0f;
-            mbn.Vz().x *= -1.0f;
             perMtx = mbn * mdl->mtx;
         }
 
@@ -634,11 +620,6 @@ void BLADE::TIEITEM_INFO::DrawItem(VDX9RENDER *rs, unsigned int blendValue, MODE
             mt.Pos() = CVECTOR(lb.m[3][0], lb.m[3][1], lb.m[3][2]);
 
             CMatrix mbn = mt * bones[lb.bones[0]];
-            mbn.Pos().x *= -1.0f;
-            mbn.Vx().x *= -1.0f;
-            mbn.Vy().x *= -1.0f;
-            mbn.Vz().x *= -1.0f;
-
             CMatrix scl;
             scl.Vx().x = -1.0f;
             scl.Vy().y = 1.0f;


### PR DESCRIPTION
Improves animation blending performance by ~20-33%
Since for some heavy scenes blending can use up to 25% CPU(single core) time, this micro-optimization is essential until we implement AVERTEX0 shader