### PR TITLE
location: backport camera MSGs from DMC

### DIFF
--- a/src/libs/location/src/LocationCamera.h
+++ b/src/libs/location/src/LocationCamera.h
@@ -203,6 +203,8 @@ class LocationCamera : public Entity
     float TrackPauseProcess();
 
     PathTracks m_track;
+
+    bool forcedPos = false;
 };
 
 inline void LocationCamera::LockFPMode(bool isLock)

--- a/src/libs/shared_headers/include/shared/messages.h
+++ b/src/libs/shared_headers/include/shared/messages.h
@@ -201,6 +201,7 @@
 #define MSG_CAMERA_FREE 30514 // "l" free flight of the camera
 
 #define MSG_CAMERA_SLEEP 30520 // "ll" stop the camera (1) or resume (0)
+#define MSG_CAMERA_SET_RADIUS 30521 // "lf" set radius
 
 // Blots on the ship
 #define MSG_BLOTS_SETMODEL 30600 // "li" set the model, model_id


### PR DESCRIPTION
This adds backport of 2 messages from the DMC engine: set radius and pos-to-pos view.
There is one more related to the deck camera but I have no idea of its purpose so I decided not to add it yet.