### PR TITLE
Fix worldmap zoom

### DIFF
--- a/src/libs/pcs_controls/src/pcs_controls.cpp
+++ b/src/libs/pcs_controls/src/pcs_controls.cpp
@@ -625,7 +625,7 @@ void PCS_CONTROLS::HandleEvent(const InputEvent &evt)
     else if (evt.type == InputEvent::MouseWheel)
     {
         auto dxdy = std::get<MousePos>(evt.data);
-        nMouseWheel += dxdy.y;
+        nMouseWheel += dxdy.y * WHEEL_DELTA; // Some code relies on nMouseWheel absolute value...
         core.Event("evMouseWeel", "l", static_cast<short>(dxdy.y));
     }
 }


### PR DESCRIPTION
After the SDL switch worldmap zoom stopped working because it relied on the absolute value of nMouseWheel which previously was a multiple of WHEEL_DELTA (120) and SDL output is +1 or -1. See more at https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mousewheel