### PR TITLE
Fix TEHO-specific fencing stun chance

### DIFF
--- a/src/libs/location/src/Character.cpp
+++ b/src/libs/location/src/Character.cpp
@@ -4211,17 +4211,33 @@ void Character::UpdateAnimation()
                     fgtSetIndex = -1;
                     isFired = false;
                     break;
-                case fgt_hit_attack: // The reaction of hitting a character putting him into the stall
-                    if (rand() % 100 < stunChance)
+                case fgt_hit_attack: { // The reaction of hitting a character putting him into the stall
+                    const auto version = core.GetTargetEngineVersion();
+
+                    if (version == storm::ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS)
                     {
-                        core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
-                        if (!(isSet = SetAction(hit[fgtSetIndex].name, hit[fgtSetIndex].tblend, 0.0f, 1.0f, true)))
+                        if (IsPlayer() && rand() % 100 >= 50)
                         {
-                            core.Trace("Character animation: not set fight attack hit action: \"%s\"",
-                                       hit[fgtSetIndex].name);
+                            break;
                         }
                     }
+
+                    if (version >= storm::ENGINE_VERSION::TO_EACH_HIS_OWN)
+                    {
+                        if (rand() % 100 >= stunChance)
+                        {
+                            break;
+                        }
+                    }
+
+                    core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
+                    if (!(isSet = SetAction(hit[fgtSetIndex].name, hit[fgtSetIndex].tblend, 0.0f, 1.0f, true)))
+                    {
+                        core.Trace("Character animation: not set fight attack hit action: \"%s\"",
+                                   hit[fgtSetIndex].name);
+                    }
                     break;
+                }
                 case fgt_blockbreak: // The reaction of hitting a character putting him into the stall
                     core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
                     if (!(isSet = SetAction(blockbreak.name, blockbreak.tblend, 0.0f, 1.0f, true)))
@@ -4254,16 +4270,32 @@ void Character::UpdateAnimation()
                         core.Trace("Character animation: not set fight round hit action: \"%s\"", hitRound.name);
                     }
                     break;
-                case fgt_hit_fire: // The reaction from the shot, putting him into stall
-                    if (rand() % 100 < stunChance)
+                case fgt_hit_fire: { // The reaction from the shot, putting him into stall
+                    const auto version = core.GetTargetEngineVersion();
+
+                    if (version == storm::ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS)
                     {
-                        core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
-                        if (!(isSet = SetAction(hitFire.name, hitFire.tblend, 0.0f, 0.0f, true)))
+                        if (IsPlayer() && rand() % 100 >= 50)
                         {
-                            core.Trace("Character animation: not set fight fire hit action: \"%s\"", hitFire.name);
+                            break;
                         }
                     }
+
+                    if (version >= storm::ENGINE_VERSION::TO_EACH_HIS_OWN)
+                    {
+                        if (rand() % 100 >= stunChance)
+                        {
+                            break;
+                        }
+                    }
+
+                    core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
+                    if (!(isSet = SetAction(hitFire.name, hitFire.tblend, 0.0f, 0.0f, true)))
+                    {
+                        core.Trace("Character animation: not set fight fire hit action: \"%s\"", hitFire.name);
+                    }
                     break;
+                }
                 case fgt_block: // Saber protection
                     core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
                     if (_stricmp(pWeaponID, "topor") == 0)

--- a/src/libs/location/src/Character.cpp
+++ b/src/libs/location/src/Character.cpp
@@ -539,7 +539,7 @@ Character::Character()
     fgtCurIndex = fgtSetIndex = -1;
     isParryState = false;
     isFeintState = false;
-    isStunEnable = true;
+    stunChance = 100;
     //
     isMove = false;
     isBack = false;
@@ -4212,13 +4212,7 @@ void Character::UpdateAnimation()
                     isFired = false;
                     break;
                 case fgt_hit_attack: // The reaction of hitting a character putting him into the stall
-                    if (IsPlayer() && !isStunEnable)
-                    // boal did not find a better one, but ours always has this ID, it will work
-                    {
-                        if (rand() % 100 >= 50)
-                            break; // boal doesn't always break into animation
-                    }
-                    if (isStunEnable)
+                    if (rand() % 100 < stunChance)
                     {
                         core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
                         if (!(isSet = SetAction(hit[fgtSetIndex].name, hit[fgtSetIndex].tblend, 0.0f, 1.0f, true)))
@@ -4261,12 +4255,7 @@ void Character::UpdateAnimation()
                     }
                     break;
                 case fgt_hit_fire: // The reaction from the shot, putting him into stall
-                    if (IsPlayer() && !isStunEnable)
-                    {
-                        if (rand() % 100 >= 50)
-                            break; // boal doesn't always break into animation
-                    }
-                    if (isStunEnable)
+                    if (rand() % 100 < stunChance)
                     {
                         core.Send_Message(blade, "ll", MSG_BLADE_TRACE_OFF, 0);
                         if (!(isSet = SetAction(hitFire.name, hitFire.tblend, 0.0f, 0.0f, true)))

--- a/src/libs/location/src/Character.h
+++ b/src/libs/location/src/Character.h
@@ -578,7 +578,7 @@ class Character : public Entity
     ActionCharacter recoil;      // Bounce back
     ActionCharacter strafe_l;    // Bounce to the left
     ActionCharacter strafe_r;    // Bounce to the right
-    bool isStunEnable;           // Is the stun allowed after the enemy's blow
+    long stunChance;             // Is the stun allowed after the enemy's blow
     // Logical state
     FightAction fgtCurType;   // Current action type
     long fgtCurIndex;         // Current Activity Index

--- a/src/libs/location/src/NPCharacter.cpp
+++ b/src/libs/location/src/NPCharacter.cpp
@@ -61,7 +61,7 @@ NPCharacter::NPCharacter() : taskstack{}
     defencePrbBlock = 0.9f;
     defencePrbParry = 0.1f;
     isRecoilEnable = true;
-    isStunEnable = true; // ugeen 29.12.10
+    stunChance = 100;
     // Shooting
     fireCur = 0.0f;
     isFireEnable = true;
@@ -144,10 +144,10 @@ bool NPCharacter::PostInit()
     tmpBool = isFireEnable;
     if (vd && vd->Get(tmpBool))
         isFireEnable = tmpBool != 0;
-    vd = core.Event("NPC_Event_EnableStun", "i", GetId());
-    tmpBool = isStunEnable;
-    if (vd && vd->Get(tmpBool))
-        isStunEnable = tmpBool != 0;
+    vd = core.Event("NPC_Event_StunChance", "i", GetId());
+    auto tmpLong = stunChance;
+    if (vd && vd->Get(tmpLong))
+        stunChance = tmpLong;
     // Parameter normalization
     if (attackCur < 0.0f)
         attackCur = 0.0f;
@@ -626,11 +626,6 @@ void NPCharacter::UpdateFightCharacter(float dltTime)
         // else
         // CmdStay();
     }
-
-    VDATA *vd = core.Event("NPC_Event_EnableStun", "i", GetId());
-    long tmpBool = isStunEnable;
-    if (vd && vd->Get(tmpBool))
-        isStunEnable = tmpBool != 0;
 
     float kdst;
 

--- a/src/libs/location/src/NPCharacter.cpp
+++ b/src/libs/location/src/NPCharacter.cpp
@@ -145,9 +145,12 @@ bool NPCharacter::PostInit()
     if (vd && vd->Get(tmpBool))
         isFireEnable = tmpBool != 0;
     vd = core.Event("NPC_Event_StunChance", "i", GetId());
-    auto tmpLong = stunChance;
-    if (vd && vd->Get(tmpLong))
-        stunChance = tmpLong;
+    if (core.GetTargetEngineVersion() >= storm::ENGINE_VERSION::TO_EACH_HIS_OWN)
+    {
+        auto tmpLong = stunChance;
+        if (vd && vd->Get(tmpLong))
+            stunChance = tmpLong;
+    }
     // Parameter normalization
     if (attackCur < 0.0f)
         attackCur = 0.0f;


### PR DESCRIPTION
This is a change of a TEHO-specific feature, where characters would not always be stunned by an attack. It had a bug where the player character had semi-random stuns.