### PR TITLE
engine: remove floating point precision format when converting to string

### DIFF
--- a/src/apps/ENGINE/src/data.cpp
+++ b/src/apps/ENGINE/src/data.cpp
@@ -1675,7 +1675,7 @@ bool DATA::Plus(DATA *pV)
             Set(sValue + std::to_string(pV->lValue));
             break;
         case VAR_FLOAT:
-            Set(sValue + fmt::format("{:.5f}", pV->fValue));
+            Set(sValue + fmt::format("{}", pV->fValue));
             break;
         case VAR_STRING:
             Set(sValue + pV->sValue);


### PR DESCRIPTION
gcvt was replaced with fmt::format with the same precision.
fmt::format follows sprintf semantic; it cannot match gcvt behaviour without manual transformation.
Also, I see no point in clipping float with a buffer size of `5` in general.
So, I removed precision in order to remove surplus 'width' precision.
Let's see if it will bloat something due to potentially long mantissa