### PR TITLE
engine: empty strings allocated on pseudo-stack

### DIFF
--- a/src/apps/ENGINE/src/data.cpp
+++ b/src/apps/ENGINE/src/data.cpp
@@ -975,6 +975,7 @@ void DATA::ClearType()
     AttributesClass = nullptr;
     Data_type = UNKNOWN;
     pReference = nullptr;
+    sValue.clear();
 }
 
 void DATA::SetType(S_TOKEN_TYPE _element_type, uint32_t array_size)


### PR DESCRIPTION
This is kinda weird but mirrors the original behavior that was changed in #142