### PR TITLE
window,engine: (!) rework window creation

### DIFF
--- a/src/apps/ENGINE/CMakeLists.txt
+++ b/src/apps/ENGINE/CMakeLists.txt
@@ -7,7 +7,6 @@ STORM_SETUP(
     common
     diagnostics
     util
-    window
 
     # VM
     animals
@@ -48,6 +47,7 @@ STORM_SETUP(
     touch
     water_rings
     weather
+    window
     worldmap
     xinterface
 	

--- a/src/apps/ENGINE/src/Core.cpp
+++ b/src/apps/ENGINE/src/Core.cpp
@@ -935,6 +935,26 @@ void CORE::stopFrameProcessing()
     stopFrameProcessing_ = true;
 }
 
+void CORE::setRunning(bool isRunning)
+{
+    isRunning_ = isRunning;
+}
+
+bool CORE::isRunning()
+{
+    return isRunning_;
+}
+
+void CORE::setActive(bool isActive)
+{
+    isActive_ = isActive;
+}
+
+bool CORE::isActive()
+{
+    return isActive_;
+}
+
 void CORE::loadCompatibilitySettings(INIFILE &inifile)
 {
     using namespace storm;

--- a/src/libs/Common/include/core.h
+++ b/src/libs/Common/include/core.h
@@ -156,12 +156,21 @@ class CORE
 
     void stopFrameProcessing();
 
+    void setRunning(bool isRunning);
+    [[nodiscard]] bool isRunning();
+
+    void setActive(bool isActive);
+    [[nodiscard]] bool isActive();
+
   private:
     void loadCompatibilitySettings(INIFILE &inifile);
 
-    storm::ENGINE_VERSION targetVersion_ = storm::ENGINE_VERSION::LATEST;
+    storm::ENGINE_VERSION targetVersion_{storm::ENGINE_VERSION::LATEST};
 
-    bool stopFrameProcessing_ = false;
+    bool stopFrameProcessing_{false};
+
+    bool isRunning_{true};
+    bool isActive_{true};
 };
 
 // core instance

--- a/src/libs/Window/CMakeLists.txt
+++ b/src/libs/Window/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME window
-    TYPE library
-    DEPENDENCIES sdl2
+    TYPE storm_module
+    DEPENDENCIES common util sdl2
 )

--- a/src/libs/Window/include/OSWindow.hpp
+++ b/src/libs/Window/include/OSWindow.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <memory>
 #include <string>
 
 namespace storm
@@ -60,8 +59,5 @@ class OSWindow
 
     //! Os-depended window handler (i.e. HWND on Windows)
     virtual void *OSHandle() = 0;
-
-    //! Create new window
-    static std::shared_ptr<OSWindow> Create(int width, int height, bool fullscreen);
 };
 } // namespace storm

--- a/src/libs/Window/src/SDLWindow.hpp
+++ b/src/libs/Window/src/SDLWindow.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
 #include <OSWindow.hpp>
-#include <SDL.h>
+
 #include <map>
+
+#include <SDL.h>
 
 namespace storm
 {
 class SDLWindow : public OSWindow
 {
   public:
-    SDLWindow(int width, int height, bool fullscreen);
+    SDLWindow();
     ~SDLWindow() override;
 
     void Show() override;
@@ -29,6 +31,8 @@ class SDLWindow : public OSWindow
     void Unsubscribe(int id) override;
 
     void *OSHandle() override;
+    
+    bool Init(int width, int height, bool fullscreen, const char * title);
 
     SDL_Window *SDLHandle();
     void ProcessEvent(const SDL_WindowEvent &evt);
@@ -36,9 +40,9 @@ class SDLWindow : public OSWindow
   private:
     static int SDLEventHandler(void *userdata, SDL_Event *evt);
 
-    std::unique_ptr<SDL_Window, std::function<void(SDL_Window *)>> window_ = nullptr;
-    uint32_t sdlID_;
-    bool fullscreen_ = false;
+    std::unique_ptr<SDL_Window, std::function<void(SDL_Window *)>> window_;
+    uint32_t sdlID_{};
+    bool fullscreen_{};
     std::map<int, EventHandler> handlers_;
 };
 } // namespace storm

--- a/src/libs/Window/src/Window.cpp
+++ b/src/libs/Window/src/Window.cpp
@@ -1,0 +1,67 @@
+#include "core.h"
+#include "entity.h"
+#include "SDLWindow.hpp"
+#include "vfile_service.h"
+#include "vmodule_api.h"
+#include "storm/fs.h"
+
+namespace
+{
+
+void HandleWindowEvent(const storm::OSWindow::Event &event)
+{
+    if (event == storm::OSWindow::Closed)
+    {
+        core.setRunning(false);
+        core.Event("DestroyWindow", nullptr);
+    }
+    else if (event == storm::OSWindow::FocusGained)
+    {
+        core.setActive(true);
+        core.AppState(true);
+    }
+    else if (event == storm::OSWindow::FocusLost)
+    {
+        core.setActive(false);
+        core.AppState(false);
+    }
+}
+
+} // namespace
+
+namespace storm
+{
+
+class MainWindow final : public Entity, SDLWindow
+{
+public:
+    bool Init() override
+    {
+        if (const auto ini = fio->OpenIniFile(fs::ENGINE_INI_FILE_NAME))
+        {
+            const auto width = ini->GetLong(nullptr, "screen_x", 1024);
+            const auto height = ini->GetLong(nullptr, "screen_y", 768);
+            const auto full_screen = ini->GetLong(nullptr, "full_screen", false);
+            const auto title = AttributesPointer->GetAttribute("title");
+
+            const auto success = SDLWindow::Init(width, height, full_screen, title);
+            if(success)
+            {
+                core.Set_Hwnd(static_cast<HWND>(SDLWindow::OSHandle()));
+                SDLWindow::Subscribe(HandleWindowEvent);
+                SDLWindow::Show();
+            }
+
+            return success;
+        }
+
+        spdlog::critical("MainWindow: cannot read configuration");
+        return false;
+    }
+
+    void ProcessStage(Stage stage, uint32_t delta) override { }
+};
+
+CREATE_CLASS(MainWindow);
+
+} // namespace storm

--- a/src/libs/renderer/src/sdevice.cpp
+++ b/src/libs/renderer/src/sdevice.cpp
@@ -5,7 +5,6 @@
 #include "Entity.h"
 #include "inlines.h"
 #include "s_import_func.h"
-#include "script_libriary.h"
 #include "texture.h"
 #include "v_s_stack.h"
 


### PR DESCRIPTION
This is meant to be a basement for future features.
Basically, two things are planned: an ability to manage the main window from scripts (a basic example is shown in the snippet below) and to have entity-level access to window handles.

❗❗❗ This requires changes from the scripts' side and therefore shall be merged along with corresponding changes to the script codebases.

Example of integration:
```
void CreateMainWindow() {
	object MainWindow;
	MainWindow.title = VERSION_NUMBER1;
	CreateEntity(&MainWindow, "MainWindow");
}

void Main()
{
	CreateMainWindow();
...
```
