### PR TITLE
xinterface: disabled text for checkbox

### DIFF
--- a/src/libs/xinterface/src/Nodes/xi_checkbuttons.cpp
+++ b/src/libs/xinterface/src/Nodes/xi_checkbuttons.cpp
@@ -34,7 +34,9 @@ void CXI_CHECKBUTTONS::Draw(bool bSelected, uint32_t Delta_Time)
             dwColor = m_dwSelectFontColor;
         if (button->bDisable)
             dwColor = m_dwDisableFontColor;
-
+        if (!m_bSelected)
+            dwColor = m_dwDisableFontColor;
+        
         auto fX = static_cast<float>(m_rect.left);
         auto fY = static_cast<float>(m_rect.top);
         if (m_bIndividualPos && button->bSetPos)


### PR DESCRIPTION
This brings back additional conditions for the disabled text in CXI_CHECKBUTTONS. Semantic is unclear, but TEHO relies on that behaviour