### PR TITLE
Fix crash caused by some broken models

### DIFF
--- a/src/libs/geometry/src/collide.cpp
+++ b/src/libs/geometry/src/collide.cpp
@@ -311,6 +311,11 @@ rec_loop:;
         {
             const long face = (static_cast<long>(*(pface + 2)) << 16) | (static_cast<long>(*(pface + 1)) << 8) |
                               (static_cast<long>(*(pface + 0)) << 0);
+            // "fix" for broken models
+            if (face < 0 || face >= sizeof(trgclip) / sizeof(*trgclip))
+            {
+                continue;
+            }
 
             // this triangle was added before
             if (trgclip[face] != attempt)


### PR DESCRIPTION
Some corrupted models (Khael Roa temple, Tenochtitlan) cause crashes because of corrupted BSP. Once these models are fixed, this will no longer be needed, but I can't do it with these old instruments like Maya 5.0. Waiting for Arty's plugins to be finished to fix these models.