### PR TITLE
renderer: add vsync and msaa options

### DIFF
--- a/src/libs/renderer/src/sdevice.h
+++ b/src/libs/renderer/src/sdevice.h
@@ -691,6 +691,11 @@ bool SetCurFont (long fontID); // returns true if the given font is installed
     long progressFramesCountX;
     long progressFramesCountY;
 
+    // new renderer settings
+    bool vSyncEnabled;
+    uint32_t msaa;
+
+
     D3DPRESENT_PARAMETERS d3dpp;
 
     CMatrix mView, mWorld, mProjection;


### PR DESCRIPTION
I'm including this now as I decided to postpone introducing new configuration system
Now, by default vsync is disabled and msaa is set to the available maximum
This can be configured in engine.ini (root section, "vsync" and "msaa" fields)
