### PR TITLE
model, ship: add MSG_MODEL_SUBSTITUTE_GEOMETRY_NODE message

### DIFF
--- a/src/libs/Common/include/model.h
+++ b/src/libs/Common/include/model.h
@@ -4,7 +4,6 @@
 #include "Matrix.h"
 #include "geos.h"
 #include "object.h"
-#include "vmodule_api.h"
 
 class NODER;
 
@@ -53,6 +52,8 @@ class NODE
                       const CMatrix &globm, NODER *par, const char *lmPath) = 0;
 
     virtual float Trace(const CVECTOR &src, const CVECTOR &dst) = 0;
+
+    virtual void SubstituteGeometry(const std::string& new_model) = 0;
 };
 
 class VDX9RENDER;

--- a/src/libs/model/src/model.cpp
+++ b/src/libs/model/src/model.cpp
@@ -393,6 +393,19 @@ uint64_t MODELR::ProcessMessage(MESSAGE &message)
         if (root)
             root->SetMaxViewDist(message.Float());
         break;
+    case MSG_MODEL_SUBSTITUTE_GEOMETRY_NODE: {
+        auto &&geometry_node = message.String();
+        auto &&new_model_name = message.String();
+
+        if (auto *node = FindNode(geometry_node.c_str()))
+        {
+            node->SubstituteGeometry(new_model_name);
+        }
+        else
+        {
+            spdlog::trace("MODELR: Cannot substitute geometry node {}", geometry_node);
+        }
+    }
     }
     return 1;
 }

--- a/src/libs/model/src/modelr.h
+++ b/src/libs/model/src/modelr.h
@@ -1,16 +1,19 @@
 #pragma once
 
+#include <string>
+
 #include "dx9render.h"
 #include "geometry.h"
 #include "model.h"
 
 class NODER : public NODE
 {
-    char *sys_modelName;
-    char *sys_LightPath;
-    char *sys_TexPath;
-    char *sys_lmPath;
-    bool isReleaed;
+    std::string sys_modelName_base;
+    std::string sys_modelName_full;
+    std::string sys_LightPath;
+    std::string sys_TexPath;
+    std::string sys_lmPath;
+    bool isReleased;
 
     static long depth, node;
     uintptr_t idGeoGroup; // id of "geometry" string
@@ -54,11 +57,15 @@ class NODER : public NODE
 
     void SetTechnique(const char *name) override;
     const char *GetTechnique() override;
+    
+    // replace only this node model without touching anything else
+    void SubstituteGeometry(const std::string &new_model) override;
 
     void ReleaseGeometry();
     void RestoreGeometry();
 
     void SetMaxViewDist(float fDist);
+
 };
 
 #define MODEL_ANI_MAXBUFFERS 16

--- a/src/libs/rigging/src/Flag.cpp
+++ b/src/libs/rigging/src/Flag.cpp
@@ -151,27 +151,22 @@ uint64_t FLAG::ProcessMessage(MESSAGE &message)
         const auto eidModel = message.EntityID();
         const auto nNation = message.Long();
 
-        MODEL *host_mdl;
-        host_mdl = static_cast<MODEL *>(EntityManager::GetEntityPointer(eidModel));
+        MODEL *host_mdl = static_cast<MODEL *>(EntityManager::GetEntityPointer(eidModel));
         if (host_mdl == nullptr)
         {
             core.Trace("Missing INIT message to FLAG: bad MODEL");
+            return 0;
         }
 
         if (groupQuantity == 0)
         {
             gdata = new GROUPDATA[1];
-            if (gdata == nullptr)
-                throw std::runtime_error("Not memory allocation");
-
             groupQuantity = 1;
         }
         else
         {
             auto *const oldgdata = gdata;
             gdata = new GROUPDATA[groupQuantity + 1];
-            if (gdata == nullptr)
-                throw std::runtime_error("Not memory allocation");
             memcpy(gdata, oldgdata, sizeof(GROUPDATA) * groupQuantity);
             delete oldgdata;
             groupQuantity++;

--- a/src/libs/shared_headers/include/shared/messages.h
+++ b/src/libs/shared_headers/include/shared/messages.h
@@ -22,6 +22,8 @@
 #define MSG_MODEL_SET_FOG 20511
 #define MSG_MODEL_SET_MAX_VIEW_DIST 20512
 
+#define MSG_MODEL_SUBSTITUTE_GEOMETRY_NODE 20600 // "ss", geometry, new model name
+
 //============================================================================================
 // blade messages
 //============================================================================================

--- a/src/libs/ship/src/ship.cpp
+++ b/src/libs/ship/src/ship.cpp
@@ -1301,8 +1301,15 @@ uint64_t SHIP::ProcessMessage(MESSAGE &message)
         core.Send_Message(GetModelEID(), "ls", MSG_MODEL_SET_TECHNIQUE, sTech.c_str());
         //       MODEL * pModel = GetModel();
         //       NODE* pNode = pModel->GetNode(0);
+        break;
     }
-    break;
+    case MSG_MODEL_SUBSTITUTE_GEOMETRY_NODE: {
+        auto &&geometry_node = message.String();
+        auto &&new_model_name = message.String();
+        core.Send_Message(GetModelEID(), "lss", MSG_MODEL_SUBSTITUTE_GEOMETRY_NODE, geometry_node.c_str(),
+                          new_model_name.c_str());
+        break;
+    }
     }
     return 0;
 }


### PR DESCRIPTION
Add a new message that replaces the model for a node linked to a specified geometry locator. e.g. for guns in some models.
Sample usage:
```
ref rShip = GetRealShip(sti(pchar.Ship.Type));
SetTextureForShip(rShip, pchar);
ref ship = &pchar.ship;
SendMessage(ship, "lss", MSG_MODEL_SUBSTITUTE_GEOMETRY_NODE, "guns", "guns_variant");
SetTexturePath(0, "");
```