### PR TITLE
renderer: add configurable option for choosing video adapter

### DIFF
--- a/src/libs/renderer/src/sdevice.h
+++ b/src/libs/renderer/src/sdevice.h
@@ -694,7 +694,7 @@ bool SetCurFont (long fontID); // returns true if the given font is installed
     // new renderer settings
     bool vSyncEnabled;
     uint32_t msaa;
-
+    uint32_t videoAdapterIndex;
 
     D3DPRESENT_PARAMETERS d3dpp;
 


### PR DESCRIPTION
By default, the device with a higher index is used as I presume that if integrated GPU is present it is always at 0