### PR TITLE
Fix setting button position from script

### DIFF
--- a/src/libs/xinterface/src/Nodes/xi_textbutton.cpp
+++ b/src/libs/xinterface/src/Nodes/xi_textbutton.cpp
@@ -567,6 +567,7 @@ bool CXI_TEXTBUTTON::IsClick(int buttonID, long xPos, long yPos)
 void CXI_TEXTBUTTON::ChangePosition(XYRECT &rNewPos)
 {
     m_rect = rNewPos;
+    GetAbsoluteRect(m_rect, m_nAbsoluteRectVal);
     FillPositionIntoVertices();
 }
 


### PR DESCRIPTION
When you set button position from scripts, the coordinates range from 0 to 800, this is accounted for during initialization but not when changing position