### PR TITLE
Fix utf8 stash path

### DIFF
--- a/src/libs/util/include/storm/fs.h
+++ b/src/libs/util/include/storm/fs.h
@@ -17,9 +17,7 @@ inline path GetStashPath()
         wchar_t *str = nullptr;
         SHGetKnownFolderPath(FOLDERID_Documents, KF_FLAG_SIMPLE_IDLIST, nullptr, &str);
         path = str;
-        const auto u8str = path.u8string();
-        const std::string toUtf8(u8str.begin(), u8str.end());
-        path = fs::path(toUtf8) / "My Games" / "Sea Dogs";
+        path = path / "My Games" / "Sea Dogs";
         CoTaskMemFree(str);
     }
     return path;


### PR DESCRIPTION
``const std::string toUtf8(u8str.begin(), u8str.end());`` mangles cyrillic characters in paths, results in crashes