### PR TITLE
Fix VK_SHIFT behaviour

### DIFF
--- a/src/libs/pcs_controls/src/pcs_controls.cpp
+++ b/src/libs/pcs_controls/src/pcs_controls.cpp
@@ -346,6 +346,10 @@ bool PCS_CONTROLS::GetControlState(long control_code, CONTROL_STATE &_state_stru
                 if (!input_->KeyboardKeyState(VK_MENU))
                     pressed = input_->KeyboardKeyState(system_code);
             }
+            else if (system_code == VK_SHIFT)
+            {
+                pressed = input_->KeyboardKeyState(VK_LSHIFT) || input_->KeyboardKeyState(VK_RSHIFT);
+            }
             else
                 pressed = input_->KeyboardKeyState(system_code);
 


### PR DESCRIPTION
VK_SHIFT means either left shift is pressed or right shift is pressed, my PR brings this back