### PR TITLE
Fix TEHO's composite masts

### DIFF
--- a/src/libs/mast/src/mast.cpp
+++ b/src/libs/mast/src/mast.cpp
@@ -206,6 +206,8 @@ void MAST::Mount(entid_t modelEI, entid_t shipEI, NODE *mastNodePointer)
     const auto sailEI = EntityManager::GetEntityId("sail");
     const auto flagEI = EntityManager::GetEntityId("flag");
     const auto vantEI = EntityManager::GetEntityId("vant");
+    const auto vantlEI = EntityManager::GetEntityId("vantl");
+    const auto vantzEI = EntityManager::GetEntityId("vantz");
 
     // find the attributes
     VAI_OBJBASE *pVAI = nullptr;
@@ -241,6 +243,10 @@ void MAST::Mount(entid_t modelEI, entid_t shipEI, NODE *mastNodePointer)
         // go through all the ropes of this mast and turn them off
         if (vantEI)
             core.Send_Message(vantEI, "lip", MSG_VANT_DEL_MAST, modelEI, mastNodePointer);
+        if (vantlEI)
+            core.Send_Message(vantlEI, "lip", MSG_VANT_DEL_MAST, modelEI, mastNodePointer);
+        if (vantzEI)
+            core.Send_Message(vantzEI, "lip", MSG_VANT_DEL_MAST, modelEI, mastNodePointer);
         auto mdl = static_cast<MODEL *>(EntityManager::GetEntityPointer(model_id));
         if (mdl != nullptr)
             for (i = 0; i < 10000; i++)


### PR DESCRIPTION
Yet another fix for the masts. Vants were not always removed when a higher part of a mast was destroyed.
Before this commit: 
![image](https://user-images.githubusercontent.com/47641608/137958856-ca55f165-14c0-44d9-be49-fede47ddaf2b.png)
After: 
![image](https://user-images.githubusercontent.com/47641608/137958892-65561e94-1604-4da6-93ff-8ae441c74661.png)
