### PR TITLE
Fix AI shooting through allies logic

### DIFF
--- a/src/libs/sea_ai/src/AIShip.cpp
+++ b/src/libs/sea_ai/src/AIShip.cpp
@@ -323,9 +323,9 @@ bool AIShip::isCanFire(const CVECTOR &vFirePos) const
                 continue;
             if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, vFirePos))
                 return false;
-            if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, v1))
+            if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, vOurPos + v1))
                 return false;
-            if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, v2))
+            if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, vOurPos + v2))
                 return false;
         }
 

--- a/src/libs/sea_ai/src/AIShip.cpp
+++ b/src/libs/sea_ai/src/AIShip.cpp
@@ -304,30 +304,32 @@ void AIShip::CheckStartPosition() const
 
 bool AIShip::isCanFire(const CVECTOR &vFirePos) const
 {
-    CVECTOR v1, v2, vOurPos;
-    float fAng, fCos, fSin;
+    const auto vOurPos = GetPos();
 
-    vOurPos = GetPos();
+    const auto fAng = 8.0f * PI / 180.0f;
+    const auto fCos = cosf(fAng);
+    const auto fSin = sinf(fAng);
 
-    fAng = 8.0f * PI / 180.0f;
-    fCos = cosf(fAng), fSin = sinf(fAng);
-
-    v1 = v2 = vFirePos - vOurPos;
+    auto v1 = (vFirePos - vOurPos) / fCos;
     RotateAroundY(v1.x, v1.z, fCos, fSin);
+
+    auto v2 = (vFirePos - vOurPos) / fCos;
     RotateAroundY(v2.x, v2.z, fCos, -fSin);
 
-    for (uint32_t i = 0; i < AIShips.size(); i++)
-        if (this != AIShips[i] && isFriend(*AIShips[i]))
+    for (auto &AIShip : AIShips)
+    {
+        if (this != AIShip && isFriend(*AIShip))
         {
-            if (AIShips[i]->isDead())
+            if (AIShip->isDead())
                 continue;
-            if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, vFirePos))
+            if (AIShip->GetTouchController()->isCollision2D(vOurPos, vFirePos))
                 return false;
-            if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, vOurPos + v1))
+            if (AIShip->GetTouchController()->isCollision2D(vOurPos, vOurPos + v1))
                 return false;
-            if (AIShips[i]->GetTouchController()->isCollision2D(vOurPos, vOurPos + v2))
+            if (AIShip->GetTouchController()->isCollision2D(vOurPos, vOurPos + v2))
                 return false;
         }
+    }
 
     return true;
 }

--- a/src/libs/sea_ai/src/AIShip.cpp
+++ b/src/libs/sea_ai/src/AIShip.cpp
@@ -305,15 +305,14 @@ void AIShip::CheckStartPosition() const
 bool AIShip::isCanFire(const CVECTOR &vFirePos) const
 {
     CVECTOR v1, v2, vOurPos;
-    float fAng, fCos, fSin, fDist;
+    float fAng, fCos, fSin;
 
     vOurPos = GetPos();
 
     fAng = 8.0f * PI / 180.0f;
     fCos = cosf(fAng), fSin = sinf(fAng);
-    fDist = sqrtf(~(vOurPos - vFirePos));
 
-    v1 = v2 = fDist * !(vFirePos - vOurPos);
+    v1 = v2 = vFirePos - vOurPos;
     RotateAroundY(v1.x, v1.z, fCos, fSin);
     RotateAroundY(v2.x, v2.z, -fCos, -fSin);
 

--- a/src/libs/sea_ai/src/AIShip.cpp
+++ b/src/libs/sea_ai/src/AIShip.cpp
@@ -314,7 +314,7 @@ bool AIShip::isCanFire(const CVECTOR &vFirePos) const
 
     v1 = v2 = vFirePos - vOurPos;
     RotateAroundY(v1.x, v1.z, fCos, fSin);
-    RotateAroundY(v2.x, v2.z, -fCos, -fSin);
+    RotateAroundY(v2.x, v2.z, fCos, -fSin);
 
     for (uint32_t i = 0; i < AIShips.size(); i++)
         if (this != AIShips[i] && isFriend(*AIShips[i]))


### PR DESCRIPTION
Sometimes autoaim does not let you shoot enemies that are literally in front of you.

On this screenshot my ship can clearly shoot the galleon in the circle, but the allied warship to the left somehow does not let me.
![image](https://user-images.githubusercontent.com/47641608/138560595-cd98dfcb-8fb2-41d8-83ee-d047e2580a08.png)
