### PR TITLE
Fix rare crash when character is hit while location exiting

### DIFF
--- a/src/libs/location/src/Character.cpp
+++ b/src/libs/location/src/Character.cpp
@@ -4781,6 +4781,10 @@ inline void Character::CheckAttackHit()
     }
     // Find the surrounding characters
     auto *const location = GetLocation();
+    if (!location)
+    {
+        return;
+    }
     auto fndCharacter =
         location->supervisor.FindCharacters(this, attackDist, attackAng, 0.1f, 0.0f, false, true);
     if (fndCharacter.empty())


### PR DESCRIPTION
GetLocation() can be null if the timing is right