### PR TITLE
battle_shipsign: make picture count configurable

### DIFF
--- a/src/libs/battle_interface/src/sea/battle_shipsign.cpp
+++ b/src/libs/battle_interface/src/sea/battle_shipsign.cpp
@@ -283,6 +283,9 @@ void BIShipIcon::Init(ATTRIBUTES *pRoot, ATTRIBUTES *pA)
         if (pcTmp)
             sscanf(pcTmp, "%f,%f", &m_pntShipIconSize.x, &m_pntShipIconSize.y);
 
+        m_dwShipNCols = pA->GetAttributeAsDword("xsize");
+        m_dwShipNRows = pA->GetAttributeAsDword("ysize");
+
         for (n = 0; n < MAX_SHIP_QUANTITY; n++)
         {
             sprintf_s(param, sizeof(param), "iconoffset%d", n + 1);
@@ -765,8 +768,8 @@ void BIShipIcon::GetShipUVFromPictureIndex(long nPicIndex, FRECT &rUV)
 {
     // TODO: Make picture count configurable
     const float pictureCount = core.GetTargetEngineVersion() >= storm::ENGINE_VERSION::TO_EACH_HIS_OWN ? 16.f : 8.f;
-    const float pictureWidth = 1.0f / pictureCount;
-    const float pictureHeight = 1.0f / pictureCount;
+    const float pictureWidth = m_dwShipNCols ? 1.0f / m_dwShipNCols : 1.0f / pictureCount;
+    const float pictureHeight = m_dwShipNRows ? 1.0f / m_dwShipNRows : 1.0f / pictureCount;
 
     const float ny = std::floor(static_cast<float>(nPicIndex) / pictureCount);
     const float nx = static_cast<float>(nPicIndex) - ny * pictureCount;

--- a/src/libs/battle_interface/src/sea/battle_shipsign.h
+++ b/src/libs/battle_interface/src/sea/battle_shipsign.h
@@ -109,6 +109,8 @@ class BIShipIcon
     // FRECT m_rShipUV;
     BIFPOINT m_pntShipOffset;
     FPOINT m_pntShipIconSize;
+    uint32_t m_dwShipNCols;
+    uint32_t m_dwShipNRows;
 
     struct ShipDescr
     {


### PR DESCRIPTION
Currently I'm working on AoP Caribbean Tales open source SE conversion
It has different battle interface ship icon pictureWidth and pictureHeight than CoAS / TEHO

Also will be useful for mods like CSP

<img width="1196" alt="Снимок экрана 2021-11-01 в 02 20 15" src="https://user-images.githubusercontent.com/25062433/139604673-04083996-8d8b-4d1f-9de0-97c9ca0cd63f.png">

<img width="1198" alt="Снимок экрана 2021-11-01 в 02 19 55" src="https://user-images.githubusercontent.com/25062433/139604677-26734d8a-97ac-419d-a561-81fd49706086.png">

@mitrokosta @ugeen4 Could you test that nothing breaks on TEHO? 

