### PR TITLE
[ship] fix crash related to ships' lights

### DIFF
--- a/src/libs/ship/src/ship.h
+++ b/src/libs/ship/src/ship.h
@@ -93,7 +93,7 @@ class SHIP : public SHIP_BASE
     float fUpperShipAY, fUpperShipY;
 
     // Ships lights
-    IShipLights *pShipsLights;
+    entid_t shipLights;
 
     // Fire places
     std::vector<FirePlace> aFirePlaces;


### PR DESCRIPTION
`pShipsLights` pointer was used incorrectly by directly pointing to an entity instead of deducing it from its id.

fixes #255