### PR TITLE
[meta,diagnostics,engine] Add basic watermarking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug)
 
+set(STORM_WATERMARK_FILE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/watermark.hpp CACHE FILEPATH "Include file containing build revision, etc." FORCE)
+
 ### Set up third-party dependencies
 set(ENV{CONAN_REVISIONS_ENABLED} 1)
 conan_add_remote(NAME bincrafters
@@ -29,6 +31,7 @@ conan_cmake_run(CONANFILE conanfile.py
     BUILD missing
     OPTIONS
         output_directory=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        watermark_file=${STORM_WATERMARK_FILE}
         crash_reports=${STORM_ENABLE_CRASH_REPORTS}
         steam=${STORM_ENABLE_STEAM}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,10 @@ if(STORM_ENABLE_CRASH_REPORTS)
 	add_definitions(-DSTORM_ENABLE_CRASH_REPORTS=1)
 endif()
 
+if(STORM_WATERMARK_FILE)
+  add_definitions(-DSTORM_WATERMARK_FILE="${STORM_WATERMARK_FILE}")
+endif()
+
 if (MSVC)
     # Always generate PDBs
     add_compile_options(/Zi)

--- a/src/apps/ENGINE/src/Main.cpp
+++ b/src/apps/ENGINE/src/Main.cpp
@@ -6,6 +6,7 @@
 #include "file_service.h"
 #include "s_debug.h"
 #include "storm/fs.h"
+#include "watermark.hpp"
 
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/spdlog.h>
@@ -101,7 +102,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 #endif
     if (!lifecycleDiagnosticsGuard)
     {
-        spdlog::error("Unable to initialize lifecycle service");
+        MessageBoxA(nullptr, "Unable to initialize lifecycle service!", "Warning", MB_ICONWARNING);
     }
     else
     {
@@ -113,6 +114,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
 
     // Init logging
     spdlog::set_default_logger(storm::logging::getOrCreateLogger(defaultLoggerName));
+    spdlog::info("Logging system initialized. Running on {}", STORM_BUILD_WATERMARK_STRING);
 
     // Init core
     core.Init();

--- a/src/libs/diagnostics/include/watermark.hpp
+++ b/src/libs/diagnostics/include/watermark.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#ifdef STORM_WATERMARK_FILE
+#include STORM_WATERMARK_FILE
+#define STORM_STRINGIFY_EXPAND_(x) #x
+#define STORM_STRINGIFY_(x) STORM_STRINGIFY_EXPAND_(x)
+#define STORM_BUILD_WATERMARK_STRING STORM_STRINGIFY_(STORM_BUILD_WATERMARK)
+#else
+#error "Watermark file is not present. Check build configuration"
+#endif

--- a/src/libs/diagnostics/src/LifecycleDiagnosticsService.cpp
+++ b/src/libs/diagnostics/src/LifecycleDiagnosticsService.cpp
@@ -9,6 +9,7 @@
 #include "storm/fs.h"
 #include "vfile_service.h"
 #include "spdlog_sinks/syncable_sink.hpp"
+#include "watermark.hpp"
 
 #ifdef _UNICODE
 #include <tchar.h>
@@ -162,6 +163,7 @@ LifecycleDiagnosticsService::Guard LifecycleDiagnosticsService::initialize(const
         // TODO: make this crossplatform
         auto *options = sentry_options_new();
         sentry_options_set_dsn(options, "https://1798a1bcfb654cbd8ce157b381964525@o572138.ingest.sentry.io/5721165");
+        sentry_options_set_release(options, STORM_BUILD_WATERMARK_STRING);
         sentry_options_set_database_path(options, (fs::GetStashPath() / "sentry-db").c_str());
         sentry_options_set_handler_path(options, (getExecutableDir() / "crashpad_handler.exe").c_str());
         sentry_options_add_attachment(options, getLogsArchive().c_str());


### PR DESCRIPTION
Introduce basic build watermarking which gets printed in logs/can be sorted by with sentry.