### PR TITLE
[meta, diagnostics] enable exception elicitation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,7 @@ class StormEngine(ConanFile):
 
     # dependencies used in deploy binaries
     # conan-center
-    requires = ["zlib/1.2.11", "spdlog/1.9.2", "sentry-native/0.4.12", "7zip/19.00",
+    requires = ["zlib/1.2.11", "spdlog/1.9.2", "sentry-native/0.4.12@storm/patched", "7zip/19.00",
     # bincrafters
     "sdl2/2.0.16@bincrafters/stable",
     # storm.jfrog.io

--- a/src/libs/diagnostics/src/seh_extractor.cpp
+++ b/src/libs/diagnostics/src/seh_extractor.cpp
@@ -122,7 +122,7 @@ void seh_extractor::sink(const sink_func f, EXCEPTION_RECORD *next) const
     }
 
     // sink exc magic
-    const auto [_,size] = std::format_to_n(buf, _countof(buf), "magic={} (classified {})", magic, check_magic(magic));
+    const auto [_,size] = std::format_to_n(buf, _countof(buf), "magic={:#x} (classified {})", magic, check_magic(magic));
     buf[size] = '\0';
     f(buf);
 


### PR DESCRIPTION
Essentially substitutes sentry-native with a specially patched version in order to enable #229 ; minor printout change

thrown exception (or nested exceptions) will be logged to exceptions.log. E.g.
```
(root exception)
magic=0x19930520 (classified 1)
class std::runtime_error
Dummy runtime_error error message
```