### PR TITLE
Refactor options parsing to remove hard-coded character limit

### DIFF
--- a/src/libs/xinterface/CMakeLists.txt
+++ b/src/libs/xinterface/CMakeLists.txt
@@ -1,5 +1,6 @@
 STORM_SETUP(
     TARGET_NAME xinterface
     TYPE storm_module
-    DEPENDENCIES common ddraw amstrmid
+    DEPENDENCIES common ddraw amstrmid util
+    TEST_DEPENDENCIES catch2
 )

--- a/src/libs/xinterface/include/storm/xinterface/options_parser.hpp
+++ b/src/libs/xinterface/include/storm/xinterface/options_parser.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "attributes.h"
+
+#include <string>
+
+namespace storm {
+
+void removeCarriageReturn(std::string &str);
+
+void parseOptions(const std::string_view &str, ATTRIBUTES &attribute);
+
+} // namespace storm

--- a/src/libs/xinterface/src/storm/xinterface/options_parser.cpp
+++ b/src/libs/xinterface/src/storm/xinterface/options_parser.cpp
@@ -1,0 +1,61 @@
+#include "storm/xinterface/options_parser.hpp"
+
+namespace storm
+{
+
+namespace
+{
+
+constexpr const char VALUE_SEPARATOR = u8'=';
+constexpr const char OPTION_SEPARATOR = u8'\n';
+
+} // namespace
+
+void removeCarriageReturn(std::string &str)
+{
+    auto newLength = std::remove(str.begin(), str.end(), u8'\r');
+    if (newLength != str.end())
+    {
+        str.erase(newLength, str.end());
+    }
+}
+
+void parseOptions(const std::string_view &str, ATTRIBUTES &attribute)
+{
+    size_t option_offset = 0;
+    for (;;)
+    {
+        option_offset = str.find_first_not_of(" \t\n", option_offset);
+        if (option_offset == std::string_view::npos)
+        {
+            break;
+        }
+
+        const size_t name_offset = option_offset;
+        const size_t name_end = str.find_first_of(VALUE_SEPARATOR, option_offset);
+        if (name_end == std::string_view::npos)
+        {
+            break;
+        }
+        const size_t name_length = name_end - name_offset;
+
+        const size_t value_offset = name_offset + name_length + 1;
+        size_t value_end = str.find_first_of(OPTION_SEPARATOR, value_offset);
+        if (value_end == std::string_view::npos)
+        {
+            value_end = str.length();
+        }
+        const size_t value_length = value_end - value_offset;
+
+        // TODO: Update ATTRIBUTES to support string_view so we don't have to allocate memory
+        const auto name = std::string(str.substr(name_offset, name_length));
+        const auto value = std::string(str.substr(value_offset, value_length));
+
+        ATTRIBUTES *pA = attribute.CreateSubAClass(&attribute, name.c_str());
+        pA->SetValue(value.c_str());
+
+        option_offset = value_offset + value_length;
+    }
+}
+
+} // namespace storm

--- a/src/libs/xinterface/src/xinterface.h
+++ b/src/libs/xinterface/src/xinterface.h
@@ -269,7 +269,7 @@ class XINTERFACE : public XINTERFACE_BASE
     void IncrementGameTime(uint32_t dwDeltaTime);
     // Options functions
     void SaveOptionsFile(const char *fileName, ATTRIBUTES *pAttr);
-    void LoadOptionsFile(const char *fileName, ATTRIBUTES *pAttr);
+    void LoadOptionsFile(std::string_view filename, ATTRIBUTES *pAttr);
     //
     int LoadIsExist();
     //

--- a/src/libs/xinterface/testsuite/main.cpp
+++ b/src/libs/xinterface/testsuite/main.cpp
@@ -1,0 +1,7 @@
+#define CATCH_CONFIG_MAIN
+
+#ifdef _WIN32
+#define CATCH_CONFIG_WINDOWS_CRTDBG
+#endif
+
+#include <catch2/catch.hpp>

--- a/src/libs/xinterface/testsuite/options_parser.cpp
+++ b/src/libs/xinterface/testsuite/options_parser.cpp
@@ -1,0 +1,138 @@
+#include "storm/xinterface/options_parser.hpp"
+
+#include <catch2/catch.hpp>
+
+namespace
+{
+
+// TODO: Either move STRING_CODEC outside of Engine or make a re-usable codec for testing
+class TestStringCodec : public VSTRING_CODEC
+{
+  public:
+    uint32_t GetNum() override
+    {
+        return map_.size();
+    }
+
+    uint32_t Convert(const char *pString) override
+    {
+        std::string str(pString);
+        const uint32_t hash = std::hash<std::string>{}(str);
+        map_.emplace(hash, str);
+        return hash;
+    }
+
+    uint32_t Convert(const char *pString, long iLen) override
+    {
+        std::string str(pString, iLen);
+        const uint32_t hash = std::hash<std::string>{}(str);
+        map_.emplace(hash, str);
+        return hash;
+    }
+
+    const char *Convert(uint32_t code) override
+    {
+        return map_[code].c_str();
+    }
+
+    void VariableChanged() override
+    {
+    }
+
+  private:
+    std::unordered_map<uint32_t, std::string> map_;
+};
+
+} // namespace
+
+TEST_CASE("Remove carriage return characters from string", "[xinterface]")
+{
+    using namespace storm;
+    using namespace std::string_literals;
+
+    auto value = "Hello,\r\nWorld!\r\n"s;
+
+    storm::removeCarriageReturn(value);
+
+    CHECK(value == "Hello,\nWorld!\n");
+}
+
+TEST_CASE("Parse options", "[xinterface]")
+{
+    using namespace storm;
+    using namespace std::string_literals;
+    using namespace std::string_view_literals;
+
+    TestStringCodec string_codec{};
+
+    SECTION("With final newline")
+    {
+        auto source = "title=My title\ntext=Hello, World!\n"s;
+
+        ATTRIBUTES attribute(&string_codec);
+
+        storm::parseOptions(source, attribute);
+
+        CHECK(attribute.GetAttributesNum() == 2);
+
+        const auto title_attribute = attribute.GetAttribute("title");
+        REQUIRE(title_attribute != nullptr);
+        CHECK(title_attribute == "My title"sv);
+
+        const auto text_attribute = attribute.GetAttribute("text");
+        REQUIRE(text_attribute != nullptr);
+        CHECK(text_attribute == "Hello, World!"sv);
+    }
+
+    SECTION("Without final newline")
+    {
+        auto source = "title=My title\ntext=Hello, World!"s;
+
+        ATTRIBUTES attribute(&string_codec);
+
+        storm::parseOptions(source, attribute);
+
+        CHECK(attribute.GetAttributesNum() == 2);
+
+        const auto title_attribute = attribute.GetAttribute("title");
+        REQUIRE(title_attribute != nullptr);
+        CHECK(title_attribute == "My title"sv);
+
+        const auto text_attribute = attribute.GetAttribute("text");
+        REQUIRE(text_attribute != nullptr);
+        CHECK(text_attribute == "Hello, World!"sv);
+    }
+
+    SECTION("With long text values")
+    {
+        auto source =
+            "title=Inform the governor about the French attack.\n"
+            "text.t1=Malcolm was right about spotting French near #sisland_Oxbay#. A war fleet is upon #sOxbay# port! "
+            "I "
+            "had better get away before I am detected and destroyed with the rest of the English here.\n"
+            "text.t2=A French squadron captured the English colony, #sOxbay# on #sisland_Oxbay#. The French succeeded because the fort's defences were so weak. I escaped only by great good fortune. I suppose I should inform the governor of the main English colony - #sRedmond# on the island #sisland_Redmond#, Sir Robert Christopher Silehard, about the attack, so he can take appropriate measures. By chance, I noticed someone else also managed to escape the French. I saw a ship sailing away from the bay. I wonder who the captain was.\n"s;
+
+        ATTRIBUTES attribute(&string_codec);
+
+        storm::parseOptions(source, attribute);
+
+        CHECK(attribute.GetAttributesNum() == 2);
+        CHECK(attribute.GetAttribute("title") == "Inform the governor about the French attack."sv);
+
+        const auto text_attribute = attribute.GetAttributeClass("text");
+        REQUIRE(text_attribute != nullptr);
+        CHECK(text_attribute->GetAttributesNum() == 2);
+
+        const auto t1 = text_attribute->GetAttribute("t1");
+        REQUIRE(t1 != nullptr);
+        CHECK(
+            t1 ==
+            "Malcolm was right about spotting French near #sisland_Oxbay#. A war fleet is upon #sOxbay# port! I had better get away before I am detected and destroyed with the rest of the English here."sv);
+
+        const auto t2 = text_attribute->GetAttribute("t2");
+        REQUIRE(t2 != nullptr);
+        CHECK(
+            t2 ==
+            "A French squadron captured the English colony, #sOxbay# on #sisland_Oxbay#. The French succeeded because the fort's defences were so weak. I escaped only by great good fortune. I suppose I should inform the governor of the main English colony - #sRedmond# on the island #sisland_Redmond#, Sir Robert Christopher Silehard, about the attack, so he can take appropriate measures. By chance, I noticed someone else also managed to escape the French. I saw a ship sailing away from the bay. I wonder who the captain was."sv);
+    }
+}


### PR DESCRIPTION
Refactored the options parsing code to fix an issue with a hard-coded character limit (of 512 characters). New Horizons has some option files with longer values which was causing undefined behavior (stack corruption).

Also added some tests to verify everything works.

In terms of performance it introduces a few extra memory allocations (strings), these could be avoided by making the `ATTRIBUTES` class work with `std::string_view`s. But I don't think this will currently affect game performance noticeably.

Any feedback or suggestions welcome!