### PR TITLE
Fix crashpad initialization when built without crash reports

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,8 +47,8 @@ class StormEngine(ConanFile):
         else:
             self.__intall_lib("fmod.dll")
 
+        self.__install_bin("crashpad_handler.exe")
         if self.options.crash_reports:
-            self.__install_bin("crashpad_handler.exe")
             self.__install_bin("7za.exe")
 
         if self.options.steam:


### PR DESCRIPTION
When you build without crash reports, crashpad_handler.exe has to be present anyway, or else you get the warning message box every time