### PR TITLE
Allow MODELR to be animated

### DIFF
--- a/src/libs/model/src/model.cpp
+++ b/src/libs/model/src/model.cpp
@@ -405,6 +405,19 @@ uint64_t MODELR::ProcessMessage(MESSAGE &message)
         {
             spdlog::trace("MODELR: Cannot substitute geometry node {}", geometry_node);
         }
+        break;
+    }
+
+    case MSG_MODEL_PLAY_ACTION: {
+        if (!ani)
+        {
+            return 0;
+        }
+
+        auto &player = ani->Player(message.Long());
+        player.SetAction(message.String().c_str());
+        player.Play();
+        break;
     }
     }
     return 1;

--- a/src/libs/shared_headers/include/shared/messages.h
+++ b/src/libs/shared_headers/include/shared/messages.h
@@ -23,6 +23,7 @@
 #define MSG_MODEL_SET_MAX_VIEW_DIST 20512
 
 #define MSG_MODEL_SUBSTITUTE_GEOMETRY_NODE 20600 // "ss", geometry, new model name
+#define MSG_MODEL_PLAY_ACTION 20601 // "lls", player, action name
 
 //============================================================================================
 // blade messages


### PR DESCRIPTION
MODELR can already be created from scripts (see itemLogic.c), but these models cannot be animated. With this simple change they can. Pic related.
![image](https://user-images.githubusercontent.com/47641608/147410424-549bdb1e-50d2-41c6-99c7-d924e6e85866.png)
