### PR TITLE
[SoundService] add alt-tab sound fader

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -5,6 +5,7 @@
 #include "compiler.h"
 #include "file_service.h"
 #include "s_debug.h"
+#include "v_sound_service.h"
 #include "storm/fs.h"
 #include "watermark.hpp"
 
@@ -69,11 +70,19 @@ void HandleWindowEvent(const storm::OSWindow::Event &event)
     {
         bActive = true;
         core.AppState(bActive);
+        if (const auto soundService = static_cast<VSoundService *>(core.CreateService("SoundService")))
+        {
+            soundService->SetActiveWithFade(true);
+        }
     }
     else if (event == storm::OSWindow::FocusLost)
     {
         bActive = false;
         core.AppState(bActive);
+        if (const auto soundService = static_cast<VSoundService *>(core.CreateService("SoundService")))
+        {
+            soundService->SetActiveWithFade(false);
+        }
     }
 }
 

--- a/src/libs/sound_service/include/v_sound_service.h
+++ b/src/libs/sound_service/include/v_sound_service.h
@@ -76,6 +76,9 @@ class VSoundService : public SERVICE
 
     virtual void SetEnabled(bool _enabled) = 0;
     virtual void LoadAliasFile(const char *_filename) = 0;
+
+    virtual void SetActiveWithFade(bool active) = 0;
+
     tSoundStatistics soundStatistics;
 };
 

--- a/src/libs/sound_service/src/sound_service.h
+++ b/src/libs/sound_service/src/sound_service.h
@@ -167,6 +167,8 @@ class SoundService : public VSoundService
 
     float fPitch;
 
+    float fadeTimeInSeconds = 0.5f;
+
   public:
     SoundService();
     ~SoundService() override;
@@ -209,6 +211,8 @@ class SoundService : public VSoundService
     bool SetScheme(const char *_schemeName) override;
     bool AddScheme(const char *_schemeName) override;
     void SetEnabled(bool _enabled) override;
+
+    void SetActiveWithFade(bool active) override;
 
     void DebugDraw();
     void DebugPrint3D(const CVECTOR &pos3D, float rad, long line, float alpha, uint32_t color, float scale,


### PR DESCRIPTION
0.5s by default, configurable with engine.ini:
[sound]
fade_time = X.Y

0 - disable fade