### PR TITLE
Fix mouse axis on windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,9 +16,7 @@ class StormEngine(ConanFile):
 
     # dependencies used in deploy binaries
     # conan-center
-    requires = ["zlib/1.2.11", "spdlog/1.9.2", "sentry-native/0.4.12@storm/patched", "7zip/19.00", "fast_float/3.4.0",
-    # bincrafters
-    "sdl2/2.0.16@bincrafters/stable",
+    requires = ["zlib/1.2.11", "spdlog/1.9.2", "sentry-native/0.4.12@storm/patched", "7zip/19.00", "fast_float/3.4.0", "sdl/2.0.18",    
     # storm.jfrog.io
     "directx/9.0@storm/prebuilt", "fmod/2.1.11@storm/prebuilt"]
     # aux dependencies (e.g. for tests)

--- a/src/apps/engine/CMakeLists.txt
+++ b/src/apps/engine/CMakeLists.txt
@@ -54,7 +54,7 @@ STORM_SETUP(
     # external
     fast_float
     sentry-native
-    sdl2
+    sdl
     zlib
 
     # system

--- a/src/apps/engine/src/file_service.cpp
+++ b/src/apps/engine/src/file_service.cpp
@@ -1,9 +1,8 @@
 #include "file_service.h"
 #include "core.h"
 #include "storm_assert.h"
-#include "utf8.h"
 
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <exception>
 #include <storm/string_compare.hpp>
 #include <string>

--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -12,7 +12,7 @@
 #include <spdlog/spdlog.h>
 
 #include <os_window.hpp>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 
 VFILE_SERVICE *fio = nullptr;
 S_DEBUG *CDebug = nullptr;

--- a/src/libs/input/CMakeLists.txt
+++ b/src/libs/input/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME input
     TYPE library
-    DEPENDENCIES sdl2
+    DEPENDENCIES sdl
 )

--- a/src/libs/input/include/input.hpp
+++ b/src/libs/input/include/input.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <functional>
-#include <SDL_scancode.h>
+#include <SDL2/SDL_scancode.h>
 #include <variant>
 
 namespace storm

--- a/src/libs/input/src/sdl_input.cpp
+++ b/src/libs/input/src/sdl_input.cpp
@@ -1,9 +1,9 @@
 #include "sdl_input.hpp"
 
-#include <SDL.h>
-#include <SDL_system.h>
-#include <SDL_video.h>
-#include <windows.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_system.h>
+#include <SDL2/SDL_video.h>
+#include <Windows.h>
 #include <map>
 
 namespace storm

--- a/src/libs/input/src/sdl_input.cpp
+++ b/src/libs/input/src/sdl_input.cpp
@@ -288,10 +288,13 @@ inline unsigned int keyToSDL(KeyboardKey key)
 }
 } // namespace
 
-SDLInput::SDLInput() : keyStates_(nullptr)
+SDLInput::SDLInput()
 {
     keyStates_ = SDL_GetKeyboardState(nullptr);
+#ifndef _WIN32
+    // since SDL 2.0.18 breaks WINAPI mouse api
     SDL_SetRelativeMouseMode(SDL_TRUE);
+#endif
     SDL_AddEventWatch(&SDLEventHandler, this);
     OpenController();
 }

--- a/src/libs/input/src/sdl_input.hpp
+++ b/src/libs/input/src/sdl_input.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <input.hpp>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <map>
 
 namespace storm

--- a/src/libs/pcs_controls/src/pcs_controls.cpp
+++ b/src/libs/pcs_controls/src/pcs_controls.cpp
@@ -630,18 +630,18 @@ void PCS_CONTROLS::HandleEvent(const InputEvent &evt)
     }
     else if (evt.type == InputEvent::KeyboardText)
     {
-        auto text = std::get<std::string>(evt.data);
+        const auto &text = std::get<std::string>(evt.data);
         m_KeyBuffer.AddKey((char *)text.c_str(), text.length(), false);
     }
     else if (evt.type == InputEvent::MouseMove)
     {
-        auto dxdy = std::get<MousePos>(evt.data);
+        const auto &dxdy = std::get<MousePos>(evt.data);
         nMouseDx += dxdy.x;
         nMouseDy += dxdy.y;
     }
     else if (evt.type == InputEvent::MouseWheel)
     {
-        auto dxdy = std::get<MousePos>(evt.data);
+        const auto &dxdy = std::get<MousePos>(evt.data);
         nMouseWheel += dxdy.y * input_->GetWheelFactor();
         core.Event("evMouseWeel", "l", static_cast<short>(dxdy.y));
     }

--- a/src/libs/pcs_controls/src/pcs_controls.cpp
+++ b/src/libs/pcs_controls/src/pcs_controls.cpp
@@ -424,6 +424,21 @@ bool PCS_CONTROLS::GetControlState(long control_code, CONTROL_STATE &_state_stru
 
 void PCS_CONTROLS::Update(uint32_t DeltaTime)
 {
+#ifdef _WIN32
+    static int nMouseXPrev, nMouseYPrev;
+    POINT point;
+    GetCursorPos(&point);
+
+    nMouseDx = point.x - nMouseXPrev;
+    nMouseDy = point.y - nMouseYPrev;
+
+    RECT r;
+    GetWindowRect(core.GetAppHWND(), &r);
+    nMouseXPrev = r.left + (r.right - r.left) / 2;
+    nMouseYPrev = r.top + (r.bottom - r.top) / 2;
+    SetCursorPos(nMouseXPrev, nMouseYPrev);
+#endif
+
     m_ControlTree.Process();
     m_KeyBuffer.Reset();
 

--- a/src/libs/window/CMakeLists.txt
+++ b/src/libs/window/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME window
     TYPE library
-    DEPENDENCIES sdl2
+    DEPENDENCIES sdl
 )

--- a/src/libs/window/src/sdl_window.cpp
+++ b/src/libs/window/src/sdl_window.cpp
@@ -1,6 +1,6 @@
 #include "sdl_window.hpp"
 
-#include <SDL_syswm.h>
+#include <SDL2/SDL_syswm.h>
 #include <map>
 
 namespace storm

--- a/src/libs/window/src/sdl_window.hpp
+++ b/src/libs/window/src/sdl_window.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <os_window.hpp>
-#include <SDL.h>
+#include <SDL2/SDL.h>
 #include <map>
 
 namespace storm


### PR DESCRIPTION
SDL2 mouse polling is very inaccurate for some reason. The intention was to update SDL2 and check if it was fixed.
It was not and also broke the original method of pooling the mouse axis.
Therefore, I retrieved the original polling for the windows build and tweaked SDL2 init to re-enable it.