### PR TITLE
[window] Disable border when windowed

### DIFF
--- a/src/libs/window/src/sdl_window.cpp
+++ b/src/libs/window/src/sdl_window.cpp
@@ -13,6 +13,7 @@ SDLWindow::SDLWindow(int width, int height, bool fullscreen) : fullscreen_(fulls
         [](SDL_Window *w) { SDL_DestroyWindow(w); });
 
     sdlID_ = SDL_GetWindowID(window_.get());
+    SDL_SetWindowBordered(window_.get(), SDL_FALSE);
     SDL_AddEventWatch(&SDLEventHandler, this);
 }
 


### PR DESCRIPTION
- it appears when the requested screen size is lower than the actual
- when it equals the actual, it affects screen size causing improper scaling