### PR TITLE
[meta] Update sentry-native to 0.4.13

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,7 @@ class StormEngine(ConanFile):
 
     # dependencies used in deploy binaries
     # conan-center
-    requires = ["zlib/1.2.11", "spdlog/1.9.2", "sentry-native/0.4.12@storm/patched", "7zip/19.00", "fast_float/3.4.0", "sdl/2.0.18",    
+    requires = ["zlib/1.2.11", "spdlog/1.9.2", "sentry-native/0.4.13@storm/patched", "7zip/19.00", "fast_float/3.4.0", "sdl/2.0.18",
     # storm.jfrog.io
     "directx/9.0@storm/prebuilt", "fmod/2.02.05@storm/prebuilt"]
     # aux dependencies (e.g. for tests)


### PR DESCRIPTION
Fixed crashpad_exception_info_windows.patch. Added Linux support