### PR TITLE
Changed Ship Speed Influence In Cannons Aiming

### DIFF
--- a/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
+++ b/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
@@ -115,9 +115,10 @@ bool AIShipCannonController::Fire(AIShip *pEnemy)
 
     const float fDistance = GetAIShip()->GetDistance(*pEnemy);
     const float fSpeedZ1 = GetAIShip()->GetShipBasePointer()->GetCurrentSpeed();
+    const float fAng1 = pEnemy->GetShipBasePointer()->GetAng().y;
     const float fSpeedZ2 = pEnemy->GetShipBasePointer()->GetCurrentSpeed();
-    const float fAng = pEnemy->GetShipBasePointer()->GetAng().y;
-    CVECTOR vFirePos = (fSpeedZ2 * fDistance / GetSpeedV0()) * CVECTOR(sinf(fAng), 0.0f, cosf(fAng)) - fSpeedZ1 * CVECTOR(sinf(fAng), 0.0f, cosf(fAng)) ;
+    const float fAng2 = pEnemy->GetShipBasePointer()->GetAng().y;
+    CVECTOR vFirePos = (fSpeedZ2 * fDistance / GetSpeedV0()) * CVECTOR(sinf(fAng2) - sinf(fAng1), 0.0f, cosf(fAng2) - cosf(fAng1)) - fSpeedZ1 * CVECTOR(sinf(fAng1) - sinf(fAng2), 0.0f, cosf(fAng1) - cosf(fAng2)) ;
     vFirePos += pEnemy->GetPos();
 
     rs.vPos = vFirePos;

--- a/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
+++ b/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
@@ -116,7 +116,7 @@ bool AIShipCannonController::Fire(AIShip *pEnemy)
     const float fDistance = GetAIShip()->GetDistance(*pEnemy);
     const float fSpeedZ = pEnemy->GetShipBasePointer()->GetCurrentSpeed();
     const float fAng = pEnemy->GetShipBasePointer()->GetAng().y;
-    CVECTOR vFirePos = (fSpeedZ * fDistance / GetSpeedV0()) * CVECTOR(sinf(fAng), 0.0f, cosf(fAng));
+    CVECTOR vFirePos = (fSpeedZ * fDistance / GetSpeedV0()/2.0f) * CVECTOR(sinf(fAng), 0.0f, cosf(fAng));
     vFirePos += pEnemy->GetPos();
 
     rs.vPos = vFirePos;

--- a/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
+++ b/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
@@ -114,11 +114,9 @@ bool AIShipCannonController::Fire(AIShip *pEnemy)
     fFireHeight = pVData->GetFloat();
 
     const float fDistance = GetAIShip()->GetDistance(*pEnemy);
-    const float fSpeedZ1 = GetAIShip()->GetShipBasePointer()->GetCurrentSpeed();
-    const float fAng1 = pEnemy->GetShipBasePointer()->GetAng().y;
-    const float fSpeedZ2 = pEnemy->GetShipBasePointer()->GetCurrentSpeed();
-    const float fAng2 = pEnemy->GetShipBasePointer()->GetAng().y;
-    CVECTOR vFirePos = (fSpeedZ2 * fDistance / GetSpeedV0()) * CVECTOR(sinf(fAng2) - sinf(fAng1), 0.0f, cosf(fAng2) - cosf(fAng1)) - fSpeedZ1 * CVECTOR(sinf(fAng1) - sinf(fAng2), 0.0f, cosf(fAng1) - cosf(fAng2)) ;
+    const float fSpeedZ = pEnemy->GetShipBasePointer()->GetCurrentSpeed();
+    const float fAng = pEnemy->GetShipBasePointer()->GetAng().y;
+    CVECTOR vFirePos = (fSpeedZ * fDistance / GetSpeedV0() / 1.9438f) * CVECTOR(sinf(fAng), 0.0f, cosf(fAng));
     vFirePos += pEnemy->GetPos();
 
     rs.vPos = vFirePos;

--- a/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
+++ b/src/libs/sea_ai/src/ai_ship_cannon_controller.cpp
@@ -114,9 +114,10 @@ bool AIShipCannonController::Fire(AIShip *pEnemy)
     fFireHeight = pVData->GetFloat();
 
     const float fDistance = GetAIShip()->GetDistance(*pEnemy);
-    const float fSpeedZ = pEnemy->GetShipBasePointer()->GetCurrentSpeed();
+    const float fSpeedZ1 = GetAIShip()->GetShipBasePointer()->GetCurrentSpeed();
+    const float fSpeedZ2 = pEnemy->GetShipBasePointer()->GetCurrentSpeed();
     const float fAng = pEnemy->GetShipBasePointer()->GetAng().y;
-    CVECTOR vFirePos = (fSpeedZ * fDistance / GetSpeedV0()/2.0f) * CVECTOR(sinf(fAng), 0.0f, cosf(fAng));
+    CVECTOR vFirePos = (fSpeedZ2 * fDistance / GetSpeedV0()) * CVECTOR(sinf(fAng), 0.0f, cosf(fAng)) - fSpeedZ1 * CVECTOR(sinf(fAng), 0.0f, cosf(fAng)) ;
     vFirePos += pEnemy->GetPos();
 
     rs.vPos = vFirePos;


### PR DESCRIPTION
Hello. I noticed, that balls, sometimes are flying too far in forward of enemy ship and I am missing shots. So I redused ship's speed influence in cannons aiming. I've tested it on Kaleuche as the fastest ship and successfully destroy this ship. I saw good aiming, with almost zero misses on highest speed