### PR TITLE
CI: disable to build fix/* and feature/* branches

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -2,6 +2,9 @@ name: CI Windows
 
 on:
   push:
+    branches-ignore:
+      - 'fix/**'
+      - 'feature/**'
     paths-ignore:
       - 'docs/**'
       - 'tools/**'


### PR DESCRIPTION
It looks like CI is running too often. If we make it as rule to create small branches as a `fix/*` or `feature/*`, then these changes will help reduce/speed up the build.

Here is docs about CI branches: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags