### PR TITLE
CI: add skip-duplicate-actions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -13,7 +13,22 @@ on:
       - '*.md'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.1
+        with:
+          # skip concurrent jobs if they are on the same thing
+          concurrent_skipping: 'same_content'
+          # never skip PR, release or manual/scheduled runs
+          do_not_skip: '["pull_request", "release", "workflow_dispatch", "schedule"]'
+
   build-windows:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: windows-2019
     strategy:
       fail-fast: false


### PR DESCRIPTION
Check this: https://github.com/marketplace/actions/skip-duplicate-actions
Looks like that this is better solution for skipping duplicate CI.
It this PR is good, then we can close https://github.com/storm-devs/storm-engine/pull/326

Tested on my repository: https://github.com/q4a/storm-engine/pull/53
it has 2 quick `pre_job` for `push` and `PR`.
`pre_job` for `push` returned `should_skip = true` real build was skipped.
`pre_job` for `PR` returned `should_skip = false` real build did the job.