### PR TITLE
Add script caching for faster loading

### DIFF
--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -1198,6 +1198,8 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
 
     RunningSegmentID = INVALID_SEGMENT_INDEX;
 
+    script_cache_ = storm::ScriptCache();
+
     //    bool bCDStop;
     bool bFunctionBlock;
     int32_t lvalue;

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -830,8 +830,19 @@ bool COMPILER::BC_LoadSegment(const char *file_name)
 
     SegmentTable[index].Files_list = new STRINGS_LIST;
     SegmentTable[index].Files_list->SetStringDataSize(sizeof(OFFSET_INFO));
-    const bool bRes = Compile(SegmentTable[index]);
-    if (!bRes)
+    auto result = false;
+    if (use_script_cache_)
+    {
+        // attempt to load from cache first
+        result = LoadSegmentFromCache(SegmentTable[index]);
+    }
+
+    if (!result)
+    {
+        result = Compile(SegmentTable[index]);
+    }
+
+    if (!result)
     {
         delete SegmentTable[index].Files_list;
         SegmentsNum--;
@@ -842,7 +853,7 @@ bool COMPILER::BC_LoadSegment(const char *file_name)
         EventTab.InvalidateBySegmentID(id);
         DefTab.InvalidateBySegmentID(id);
     }
-    return bRes;
+    return result;
 }
 
 bool COMPILER::ProcessDebugExpression(const char *pExpression, DATA &Result)

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -7683,6 +7683,7 @@ bool COMPILER::LoadSegmentFromCache(SEGMENT_DESC &segment)
     // verify that script files were not modified
     if (!LoadFilesFromCache(reader, segment))
     {
+        segment.Files_list->Release();
         return false;
     }
 

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -7266,7 +7266,7 @@ void COMPILER::SetUseScriptCache(bool use) noexcept
     use_script_cache_ = use;
 }
 
-void COMPILER::LoadVariablesFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment)
+void COMPILER::LoadVariablesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment)
 {
     const auto size = reader.ReadData<size_t>();
     for (size_t i = 0; i < *size; ++i)
@@ -7295,7 +7295,7 @@ void COMPILER::LoadVariablesFromCache(storm::script_cache::Reader reader, SEGMEN
     }
 }
 
-void COMPILER::LoadFunctionsFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment)
+void COMPILER::LoadFunctionsFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment)
 {
     const auto size = reader.ReadData<size_t>();
     for (size_t i = 0; i < *size; ++i)
@@ -7341,7 +7341,7 @@ void COMPILER::LoadFunctionsFromCache(storm::script_cache::Reader reader, SEGMEN
     }
 }
 
-void COMPILER::LoadScriptLibrariesFromCache(storm::script_cache::Reader reader)
+void COMPILER::LoadScriptLibrariesFromCache(storm::script_cache::Reader &reader)
 {
     const auto size = reader.ReadData<size_t>();
     for (size_t i = 0; i < *size; ++i)
@@ -7365,7 +7365,7 @@ void COMPILER::LoadScriptLibrariesFromCache(storm::script_cache::Reader reader)
     }
 }
 
-void COMPILER::LoadEventHandlersFromCache(storm::script_cache::Reader reader)
+void COMPILER::LoadEventHandlersFromCache(storm::script_cache::Reader &reader)
 {
     const auto size = reader.ReadData<size_t>();
     for (size_t i = 0; i < *size; ++i)
@@ -7377,7 +7377,7 @@ void COMPILER::LoadEventHandlersFromCache(storm::script_cache::Reader reader)
     }
 }
 
-void COMPILER::LoadByteCodeFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment)
+void COMPILER::LoadByteCodeFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment)
 {
     const auto code = reader.ReadBytes();
     segment.BCode_Program_size = segment.BCode_Buffer_size = code.size();
@@ -7448,7 +7448,7 @@ std::filesystem::path COMPILER::GetSegmentCachePath(const SEGMENT_DESC &segment)
     return path;
 }
 
-void COMPILER::SaveVariablesToCache(storm::script_cache::Writer writer)
+void COMPILER::SaveVariablesToCache(storm::script_cache::Writer &writer)
 {
     writer.WriteData(script_cache_.variables.size());
     for (auto &vi : script_cache_.variables)
@@ -7471,7 +7471,7 @@ void COMPILER::SaveVariablesToCache(storm::script_cache::Writer writer)
     }
 }
 
-void COMPILER::WriteFunctionsToCache(storm::script_cache::Writer writer)
+void COMPILER::WriteFunctionsToCache(storm::script_cache::Writer &writer)
 {
     writer.WriteData(script_cache_.functions.size());
     for (auto &[fi, arguments, local_variables] : script_cache_.functions)
@@ -7501,7 +7501,7 @@ void COMPILER::WriteFunctionsToCache(storm::script_cache::Writer writer)
     }
 }
 
-void COMPILER::WriteScriptLibrariesToCache(storm::script_cache::Writer writer)
+void COMPILER::WriteScriptLibrariesToCache(storm::script_cache::Writer &writer)
 {
     writer.WriteData(script_cache_.script_libs.size());
     for (auto &lib_name : script_cache_.script_libs)
@@ -7510,7 +7510,7 @@ void COMPILER::WriteScriptLibrariesToCache(storm::script_cache::Writer writer)
     }
 }
 
-void COMPILER::WriteEventHandlersToCache(storm::script_cache::Writer writer)
+void COMPILER::WriteEventHandlersToCache(storm::script_cache::Writer &writer)
 {
     writer.WriteData(script_cache_.event_handlers.size());
     for (auto &[event, handler] : script_cache_.event_handlers)
@@ -7520,7 +7520,7 @@ void COMPILER::WriteEventHandlersToCache(storm::script_cache::Writer writer)
     }
 }
 
-void COMPILER::WriteByteCodeToCache(storm::script_cache::Writer writer, const SEGMENT_DESC &segment)
+void COMPILER::WriteByteCodeToCache(storm::script_cache::Writer &writer, const SEGMENT_DESC &segment)
 {
     auto code = std::string_view(segment.pCode, segment.pCode + segment.BCode_Program_size);
     writer.WriteBytes(code);

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -719,12 +719,6 @@ VDATA *COMPILER::ProcessEvent(const char *event_name, MESSAGE message)
     return pVD;
 }
 
-char *COMPILER::GetName()
-{
-    return SegmentTable[0].Files_list->GetString(0);
-    // return Files_list.GetString(0);
-}
-
 uint32_t COMPILER::GetSegmentIndex(uint32_t segment_id)
 {
     for (uint32_t n = 0; n < SegmentsNum; n++)
@@ -7625,7 +7619,6 @@ bool COMPILER::LoadSegmentFromCache(SEGMENT_DESC &segment)
     // verify that script files were not modified
     if (!LoadFilesFromCache(reader, segment))
     {
-        segment.Files_list->Release();
         return false;
     }
 
@@ -7659,11 +7652,6 @@ bool COMPILER::LoadFilesFromCache(storm::script_cache::Reader &reader, SEGMENT_D
     for (size_t i = 0; i < files_count; ++i)
     {
         auto file_name = std::string(reader.ReadBytes());
-        if (!segment.Files_list->AddUnicalString(file_name.c_str()))
-        {
-            continue;
-        }
-
         auto file_size = uint32_t();
         auto file_data = LoadFile(file_name.c_str(), file_size);
         computed_crc = storm::script_cache::ComputeCRC(computed_crc, {file_data, file_size});

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -385,6 +385,8 @@ void COMPILER::LoadPreprocess()
         else
             bRuntimeLog = true;
 
+        use_script_cache_ = engine_ini->GetInt("script", "use_cache", false);
+
         // if(engine_ini->GetInt("script","tracefiles",0) == 0) bScriptTrace = false;
         // else bScriptTrace = true;
     }
@@ -7190,11 +7192,6 @@ void COMPILER::PrintoutUsage()
             logTrace_->debug("  %d : %d", n, pRuntimeLogEvent[n]);
         }
     }
-}
-
-void COMPILER::SetUseScriptCache(bool use) noexcept
-{
-    use_script_cache_ = use;
 }
 
 void COMPILER::LoadVariablesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment)

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -7678,7 +7678,7 @@ bool COMPILER::LoadSegmentFromCache(SEGMENT_DESC &segment)
 
     auto data = std::vector<char>(cache_size);
     stream.read(data.data(), cache_size);
-    auto reader = storm::script_cache::Reader(data);
+    auto reader = storm::script_cache::Reader(std::string_view(data.data(), data.size()));
 
     // verify that script files were not modified
     if (!LoadFilesFromCache(reader, segment))

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -1765,7 +1765,7 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                     {
                         script_cache_.functions.back().arguments.emplace_back(lvi, bExtern);
                     }
-                } 
+                }
             }
             else
             {

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -1580,15 +1580,6 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                             return false;
                         }
 
-                        if (use_script_cache_)
-                        {
-                            script_cache_.variables.push_back(vi);
-                            script_cache_.variables.back().value = std::make_unique<DATA>();
-                            script_cache_.variables.back().value->SetVCompiler(this);
-                            script_cache_.variables.back().value->SetType(vi.type, vi.elements);
-                            script_cache_.variables.back().value->SetGlobalVarTableIndex(var_code);
-                        }
-
                         bool bNeg;
                         if (Token.GetType() == OP_EQUAL)
                         {
@@ -1629,10 +1620,6 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                             return false;
                                         }
                                         real_var->value->Set(1);
-                                        if (use_script_cache_)
-                                        {
-                                            script_cache_.variables.back().value->Set(1);
-                                        }
                                         break;
                                     case FALSE_CONST:
                                         if (vi.type != VAR_INTEGER)
@@ -1641,10 +1628,6 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                             return false;
                                         }
                                         real_var->value->Set(0);
-                                        if (use_script_cache_)
-                                        {
-                                            script_cache_.variables.back().value->Set(0);
-                                        }
                                         break;
 
                                     case NUMBER:
@@ -1654,23 +1637,9 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                             return false;
                                         }
                                         if (bNeg)
-                                        {
                                             real_var->value->Set(-atoi(Token.GetData()), aindex);
-                                            if (use_script_cache_)
-                                            {
-                                                script_cache_.variables.back().value->Set(-atoi(Token.GetData()),
-                                                                                          aindex);
-                                            }
-                                        }
                                         else
-                                        {
                                             real_var->value->Set(static_cast<int32_t>(atoll(Token.GetData())), aindex);
-                                            if (use_script_cache_)
-                                            {
-                                                script_cache_.variables.back().value->Set(
-                                                    static_cast<int32_t>(atoll(Token.GetData())), aindex);
-                                            }
-                                        }
                                         aindex++;
                                         break;
                                     case FLOAT_NUMBER:
@@ -1680,23 +1649,9 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                             return false;
                                         }
                                         if (bNeg)
-                                        {
                                             real_var->value->Set(-static_cast<float>(atof(Token.GetData())), aindex);
-                                            if (use_script_cache_)
-                                            {
-                                                script_cache_.variables.back().value->Set(
-                                                    -static_cast<float>(atof(Token.GetData())), aindex);
-                                            }
-                                        }
                                         else
-                                        {
                                             real_var->value->Set(static_cast<float>(atof(Token.GetData())), aindex);
-                                            if (use_script_cache_)
-                                            {
-                                                script_cache_.variables.back().value->Set(
-                                                    static_cast<float>(atof(Token.GetData())), aindex);
-                                            }
-                                        }
                                         aindex++;
                                         break;
                                     case STRING:
@@ -1747,71 +1702,32 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                     if (vi.type != VAR_INTEGER)
                                         break;
                                     real_var->value->Set(1);
-                                    if (use_script_cache_)
-                                    {
-                                        script_cache_.variables.back().value->Set(1);
-                                    }
                                     break;
                                 case FALSE_CONST:
                                     if (vi.type != VAR_INTEGER)
                                         break;
                                     real_var->value->Set(0);
-                                    if (use_script_cache_)
-                                    {
-                                        script_cache_.variables.back().value->Set(0);
-                                    }
                                     break;
                                 case NUMBER:
                                     if (vi.type != VAR_INTEGER)
                                         break;
                                     if (bNeg)
-                                    {
                                         real_var->value->Set(-atoi(Token.GetData()));
-                                        if (use_script_cache_)
-                                        {
-                                            script_cache_.variables.back().value->Set(-atoi(Token.GetData()));
-                                        }
-                                    }
                                     else
-                                    {
                                         real_var->value->Set(static_cast<int32_t>(atoll(Token.GetData())));
-                                        if (use_script_cache_)
-                                        {
-                                            script_cache_.variables.back().value->Set(
-                                                static_cast<int32_t>(atoll(Token.GetData())));
-                                        }
-                                    }
                                     break;
                                 case FLOAT_NUMBER:
                                     if (vi.type != VAR_FLOAT)
                                         break;
                                     if (bNeg)
-                                    {
                                         real_var->value->Set(-static_cast<float>(atof(Token.GetData())));
-                                        if (use_script_cache_)
-                                        {
-                                            script_cache_.variables.back().value->Set(
-                                                -static_cast<float>(atof(Token.GetData())));
-                                        }
-                                    }
                                     else
-                                    {
                                         real_var->value->Set(static_cast<float>(atof(Token.GetData())));
-                                        if (use_script_cache_)
-                                        {
-                                            script_cache_.variables.back().value->Set(
-                                                static_cast<float>(atof(Token.GetData())));
-                                        }
-                                    }
                                     break;
                                 case STRING:
                                     if (vi.type != VAR_STRING)
                                         break;
                                     real_var->value->Set(Token.GetData());
-                                    if (use_script_cache_)
-                                    {
-                                        script_cache_.variables.back().value->Set(Token.GetData());
-                                    }
                                     break;
                                 case UNKNOWN:
 
@@ -1821,6 +1737,13 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
                                 }
                                 Token.Get();
                             }
+                        }
+
+                        if (use_script_cache_)
+                        {
+                            auto &cached_var = script_cache_.variables.emplace_back(vi);
+                            cached_var.value = std::make_unique<DATA>();
+                            *cached_var.value = *real_var->value;
                         }
                     } while (Token.GetType() == COMMA);
                     Token.StepBack();

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -7589,7 +7589,7 @@ void COMPILER::SaveDefinesToCache(storm::script_cache::Writer &writer)
 bool COMPILER::LoadSegmentFromCache(SEGMENT_DESC &segment)
 {
     const auto path = GetSegmentCachePath(segment);
-    if (!exists(path))
+    if (auto ec = std::error_code(); !exists(path, ec) || ec)
     {
         return false;
     }

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -7444,7 +7444,7 @@ void COMPILER::WriteByteCodeToCache(storm::script_cache::Writer writer, const SE
     }
 }
 
-void COMPILER::SaveSegmentCache(const SEGMENT_DESC &segment)
+void COMPILER::SaveSegmentToCache(const SEGMENT_DESC &segment)
 {
     const auto path = GetSegmentCachePath(segment);
     create_directories(path.parent_path());

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -7314,7 +7314,7 @@ void COMPILER::LoadByteCodeFromCache(storm::script_cache::Reader &reader, SEGMEN
     const auto code = reader.ReadBytes();
     segment.BCode_Program_size = segment.BCode_Buffer_size = code.size();
     segment.pCode = new char[segment.BCode_Buffer_size];
-    std::memcpy(segment.pCode, code.data(), code.size());
+    std::ranges::copy(code, segment.pCode);
 
     // relocations data
     auto strings = std::unordered_map<uint32_t, std::string>();
@@ -7688,7 +7688,7 @@ void COMPILER::LoadDefinesFromCache(storm::script_cache::Reader &reader, SEGMENT
         case STRING: {
             auto value = reader.ReadBytes();
             const auto new_ptr = new char[value.size() + 1];
-            std::memcpy(new_ptr, value.data(), value.size());
+            std::ranges::copy(value, new_ptr);
             new_ptr[value.size()] = '\0';
             di.data4b = reinterpret_cast<uintptr_t>(new_ptr);
             break;

--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -35,7 +35,7 @@ COMPILER::COMPILER()
       pDebExpBuffer(nullptr), nDebExpBufferSize(0), pRun_fi(nullptr), bRuntimeLog(false), nRuntimeLogEventsBufferSize(0),
       nRuntimeLogEventsNum(0), nRuntimeTicks(0), bFirstRun(true), bWriteCodeFile(false),
       bDebugInfo(false), DebugSourceLine(0), pCompileTokenTempBuffer(nullptr), bDebugExpressionRun(false),
-      bTraceMode(true), nDebugTraceLineCode(0), nIOBufferSize(0), pIOBuffer(nullptr), rAP(nullptr)
+      bTraceMode(true), nDebugTraceLineCode(0), nIOBufferSize(0), pIOBuffer(nullptr), rAP(nullptr), use_script_cache_(false)
     
 {
     LabelTable.SetStringDataSize(sizeof(uint32_t));
@@ -7112,6 +7112,11 @@ void COMPILER::PrintoutUsage()
             logTrace_->debug("  %d : %d", n, pRuntimeLogEvent[n]);
         }
     }
+}
+
+void COMPILER::SetUseScriptCache(bool use) noexcept
+{
+    use_script_cache_ = use;
 }
 
 void COMPILER::FormatAllDialog(const char *directory_name)

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -17,6 +17,7 @@
 #include "strings_list.h"
 #include "token.h"
 #include "logging.hpp"
+#include "script_cache.h"
 
 #include "storm/ringbuffer_stack.hpp"
 
@@ -266,9 +267,17 @@ class COMPILER : public VIRTUAL_COMPILER
     // printout script functions usage
     void PrintoutUsage();
 
+    // use script cache?
     void SetUseScriptCache(bool use) noexcept;
 
 private:
+    bool LoadSegmentFromCache(SEGMENT_DESC &segment);
+    void LoadVariablesFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
+    void LoadFunctionsFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
+    void LoadScriptLibrariesFromCache(storm::script_cache::Reader reader);
+    void LoadEventHandlersFromCache(storm::script_cache::Reader reader);
+    void LoadByteCodeFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
+
     COMPILER_STAGE CompilerStage;
     STRINGS_LIST LabelTable;
     // STRINGS_LIST EventTable;

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -274,6 +274,7 @@ private:
     [[nodiscard]] std::filesystem::path GetSegmentCachePath(const SEGMENT_DESC &segment) const;
 
     bool LoadSegmentFromCache(SEGMENT_DESC &segment);
+    void LoadDefinesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
     void LoadVariablesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
     void LoadFunctionsFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
     void LoadScriptLibrariesFromCache(storm::script_cache::Reader &reader);
@@ -281,11 +282,12 @@ private:
     void LoadByteCodeFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
 
     void SaveSegmentToCache(const SEGMENT_DESC &segment);
+    void SaveDefinesToCache(storm::script_cache::Writer &writer);
     void SaveVariablesToCache(storm::script_cache::Writer &writer);
-    void WriteFunctionsToCache(storm::script_cache::Writer &writer);
-    void WriteScriptLibrariesToCache(storm::script_cache::Writer &writer);
-    void WriteEventHandlersToCache(storm::script_cache::Writer &writer);
-    void WriteByteCodeToCache(storm::script_cache::Writer &writer, const SEGMENT_DESC &segment);
+    void SaveFunctionsToCache(storm::script_cache::Writer &writer);
+    void SaveScriptLibrariesToCache(storm::script_cache::Writer &writer);
+    void SaveEventHandlersToCache(storm::script_cache::Writer &writer);
+    void SaveByteCodeToCache(storm::script_cache::Writer &writer, const SEGMENT_DESC &segment);
 
     COMPILER_STAGE CompilerStage;
     STRINGS_LIST LabelTable;

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -279,14 +279,13 @@ private:
     void LoadScriptLibrariesFromCache(storm::script_cache::Reader reader);
     void LoadEventHandlersFromCache(storm::script_cache::Reader reader);
     void LoadByteCodeFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
-    
+
+    void SaveSegmentToCache(const SEGMENT_DESC &segment);
     void SaveVariablesToCache(storm::script_cache::Writer writer);
     void WriteFunctionsToCache(storm::script_cache::Writer writer);
     void WriteScriptLibrariesToCache(storm::script_cache::Writer writer);
     void WriteEventHandlersToCache(storm::script_cache::Writer writer);
     void WriteByteCodeToCache(storm::script_cache::Writer writer, const SEGMENT_DESC &segment);
-
-    void SaveSegmentCache(const SEGMENT_DESC &segment);
 
     COMPILER_STAGE CompilerStage;
     STRINGS_LIST LabelTable;

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -274,6 +274,7 @@ private:
     [[nodiscard]] std::filesystem::path GetSegmentCachePath(const SEGMENT_DESC &segment) const;
 
     bool LoadSegmentFromCache(SEGMENT_DESC &segment);
+    bool LoadFilesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
     void LoadDefinesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
     void LoadVariablesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
     void LoadFunctionsFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
@@ -282,6 +283,7 @@ private:
     void LoadByteCodeFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
 
     void SaveSegmentToCache(const SEGMENT_DESC &segment);
+    void SaveFilesToCache(storm::script_cache::Writer &writer);
     void SaveDefinesToCache(storm::script_cache::Writer &writer);
     void SaveVariablesToCache(storm::script_cache::Writer &writer);
     void SaveFunctionsToCache(storm::script_cache::Writer &writer);

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -266,6 +266,8 @@ class COMPILER : public VIRTUAL_COMPILER
     // printout script functions usage
     void PrintoutUsage();
 
+    void SetUseScriptCache(bool use) noexcept;
+
 private:
     COMPILER_STAGE CompilerStage;
     STRINGS_LIST LabelTable;
@@ -343,4 +345,7 @@ private:
     // NB: pointers are safe as long as we pop elements before they expire
     static constexpr size_t CALLSTACK_SIZE = 64U;
     storm::ringbuffer_stack<std::tuple<const char *, size_t, const char *>, CALLSTACK_SIZE> callStack_;
+
+    // attempt to read/write script cache?
+    bool use_script_cache_;
 };

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -271,12 +271,22 @@ class COMPILER : public VIRTUAL_COMPILER
     void SetUseScriptCache(bool use) noexcept;
 
 private:
+    [[nodiscard]] std::filesystem::path GetSegmentCachePath(const SEGMENT_DESC &segment) const;
+
     bool LoadSegmentFromCache(SEGMENT_DESC &segment);
     void LoadVariablesFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
     void LoadFunctionsFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
     void LoadScriptLibrariesFromCache(storm::script_cache::Reader reader);
     void LoadEventHandlersFromCache(storm::script_cache::Reader reader);
     void LoadByteCodeFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
+    
+    void SaveVariablesToCache(storm::script_cache::Writer writer);
+    void WriteFunctionsToCache(storm::script_cache::Writer writer);
+    void WriteScriptLibrariesToCache(storm::script_cache::Writer writer);
+    void WriteEventHandlersToCache(storm::script_cache::Writer writer);
+    void WriteByteCodeToCache(storm::script_cache::Writer writer, const SEGMENT_DESC &segment);
+
+    void SaveSegmentCache(const SEGMENT_DESC &segment);
 
     COMPILER_STAGE CompilerStage;
     STRINGS_LIST LabelTable;
@@ -357,4 +367,5 @@ private:
 
     // attempt to read/write script cache?
     bool use_script_cache_;
+    storm::ScriptCache script_cache_;
 };

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -274,18 +274,18 @@ private:
     [[nodiscard]] std::filesystem::path GetSegmentCachePath(const SEGMENT_DESC &segment) const;
 
     bool LoadSegmentFromCache(SEGMENT_DESC &segment);
-    void LoadVariablesFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
-    void LoadFunctionsFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
-    void LoadScriptLibrariesFromCache(storm::script_cache::Reader reader);
-    void LoadEventHandlersFromCache(storm::script_cache::Reader reader);
-    void LoadByteCodeFromCache(storm::script_cache::Reader reader, SEGMENT_DESC &segment);
+    void LoadVariablesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
+    void LoadFunctionsFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
+    void LoadScriptLibrariesFromCache(storm::script_cache::Reader &reader);
+    void LoadEventHandlersFromCache(storm::script_cache::Reader &reader);
+    void LoadByteCodeFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
 
     void SaveSegmentToCache(const SEGMENT_DESC &segment);
-    void SaveVariablesToCache(storm::script_cache::Writer writer);
-    void WriteFunctionsToCache(storm::script_cache::Writer writer);
-    void WriteScriptLibrariesToCache(storm::script_cache::Writer writer);
-    void WriteEventHandlersToCache(storm::script_cache::Writer writer);
-    void WriteByteCodeToCache(storm::script_cache::Writer writer, const SEGMENT_DESC &segment);
+    void SaveVariablesToCache(storm::script_cache::Writer &writer);
+    void WriteFunctionsToCache(storm::script_cache::Writer &writer);
+    void WriteScriptLibrariesToCache(storm::script_cache::Writer &writer);
+    void WriteEventHandlersToCache(storm::script_cache::Writer &writer);
+    void WriteByteCodeToCache(storm::script_cache::Writer &writer, const SEGMENT_DESC &segment);
 
     COMPILER_STAGE CompilerStage;
     STRINGS_LIST LabelTable;

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -134,7 +134,6 @@ class COMPILER : public VIRTUAL_COMPILER
         return bCompleted;
     }
 
-    char *GetName();
     void ExitProgram();
     void ClearEvents();
 

--- a/src/apps/engine/src/compiler.h
+++ b/src/apps/engine/src/compiler.h
@@ -267,9 +267,6 @@ class COMPILER : public VIRTUAL_COMPILER
     // printout script functions usage
     void PrintoutUsage();
 
-    // use script cache?
-    void SetUseScriptCache(bool use) noexcept;
-
 private:
     [[nodiscard]] std::filesystem::path GetSegmentCachePath(const SEGMENT_DESC &segment) const;
 

--- a/src/apps/engine/src/core_impl.cpp
+++ b/src/apps/engine/src/core_impl.cpp
@@ -252,9 +252,6 @@ void CoreImpl::ProcessEngineIniFile()
         Compiler->SetProgramDirectory(String);
     }
 
-    const auto use_cache = engine_ini->GetInt("script", "use_cache", false);
-    Compiler->SetUseScriptCache(use_cache);
-
     res = engine_ini->ReadString(nullptr, "controls", String, sizeof(String), "");
     if (res)
     {

--- a/src/apps/engine/src/core_impl.cpp
+++ b/src/apps/engine/src/core_impl.cpp
@@ -252,6 +252,9 @@ void CoreImpl::ProcessEngineIniFile()
         Compiler->SetProgramDirectory(String);
     }
 
+    const auto use_cache = engine_ini->GetInt("script", "use_cache", false);
+    Compiler->SetUseScriptCache(use_cache);
+
     res = engine_ini->ReadString(nullptr, "controls", String, sizeof(String), "");
     if (res)
     {

--- a/src/apps/engine/src/script_cache.h
+++ b/src/apps/engine/src/script_cache.h
@@ -1,10 +1,8 @@
 #pragma once
 #include "s_functab.h"
 
-#include <istream>
-#include <ostream>
 #include <vector>
-#include <zlib.h>
+#include "data.h"
 
 namespace storm
 {
@@ -103,6 +101,29 @@ public:
 private:
     std::vector<char> data_;
 };
+
+inline void ReadScriptData(Reader &reader, S_TOKEN_TYPE type, DATA *data)
+{
+    switch (type)
+    {
+    case VAR_INTEGER: {
+        const auto value = reader.ReadData<long>();
+        data->Set(*value);
+        break;
+    }
+
+    case VAR_FLOAT: {
+        const auto value = reader.ReadData<float>();
+        data->Set(*value);
+        break;
+    }
+    case VAR_STRING: {
+        const auto value = reader.ReadBytes();
+        data->Set(std::string(value));
+        break;
+    }
+    }
+}
 }
 
 struct ScriptCache

--- a/src/apps/engine/src/script_cache.h
+++ b/src/apps/engine/src/script_cache.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include "data.h"
 
+#include <zlib.h>
+
 namespace storm
 {
 namespace script_cache
@@ -152,6 +154,11 @@ inline void WriteScriptData(Writer &writer, S_TOKEN_TYPE type, DATA *data)
     }
     }
 }
+
+inline uint32_t ComputeCRC(uint32_t crc, std::string_view data)
+{
+    return crc32(crc, reinterpret_cast<const Bytef *>(data.data()), data.size());
+}
 }
 
 struct ScriptCache
@@ -162,5 +169,6 @@ struct ScriptCache
     std::vector<script_cache::Function> functions;
     std::vector<VarInfo> variables;
     std::vector<script_cache::EventHandler> event_handlers;
+    uint32_t crc;
 };
 }

--- a/src/apps/engine/src/script_cache.h
+++ b/src/apps/engine/src/script_cache.h
@@ -27,6 +27,13 @@ struct EventHandler
     std::string function_name;
 };
 
+struct Define
+{
+    std::string name;
+    uint32_t type;
+    uintptr_t value;
+};
+
 class Reader final
 {
 public:
@@ -149,6 +156,7 @@ inline void WriteScriptData(Writer &writer, S_TOKEN_TYPE type, DATA *data)
 
 struct ScriptCache
 {
+    std::vector<script_cache::Define> defines;
     std::vector<std::string> script_libs;
     std::vector<std::string> files;
     std::vector<script_cache::Function> functions;

--- a/src/apps/engine/src/script_cache.h
+++ b/src/apps/engine/src/script_cache.h
@@ -87,17 +87,14 @@ public:
     template <typename T>
     void WriteData(const T &data)
     {
-        const auto size = data_.size();
-        data_.resize(size + sizeof data);
-        std::memcpy(data_.data() + size, &data, sizeof(T));
+        auto data_bytes = std::string_view(reinterpret_cast<const char *>(&data), sizeof(data));
+        std::ranges::copy(data_bytes, std::back_inserter(data_));
     }
 
     void WriteBytes(std::string_view data)
     {
         WriteData(data.size());
-        const auto size = data_.size();
-        data_.resize(size + data.size());
-        std::memcpy(data_.data() + size, data.data(), data.size());
+        std::ranges::copy(data, std::back_inserter(data_));
     }
 
     auto &GetData() const noexcept

--- a/src/apps/engine/src/script_cache.h
+++ b/src/apps/engine/src/script_cache.h
@@ -8,13 +8,6 @@ namespace storm
 {
 namespace script_cache
 {
-struct Define
-{
-    std::string name;
-    uint32_t type;
-    uintptr_t value;
-};
-
 struct FunctionLocalVariable
 {
     LocalVarInfo info;
@@ -98,6 +91,11 @@ public:
         std::memcpy(data_.data() + size, data.data(), data.size());
     }
 
+    auto &GetData() const noexcept
+    {
+        return data_;
+    }
+
 private:
     std::vector<char> data_;
 };
@@ -124,15 +122,37 @@ inline void ReadScriptData(Reader &reader, S_TOKEN_TYPE type, DATA *data)
     }
     }
 }
+
+inline void WriteScriptData(Writer &writer, S_TOKEN_TYPE type, DATA *data)
+{
+    switch (type)
+    {
+    case VAR_INTEGER: {
+        const auto value = data->GetInt();
+        writer.WriteData(value);
+        break;
+    }
+
+    case VAR_FLOAT: {
+        const auto value = data->GetFloat();
+        writer.WriteData(value);
+        break;
+    }
+    case VAR_STRING: {
+        const auto value = data->GetString();
+        writer.WriteBytes(value);
+        break;
+    }
+    }
+}
 }
 
 struct ScriptCache
 {
-    std::vector<script_cache::Define> defines;
+    std::vector<std::string> script_libs;
     std::vector<std::string> files;
     std::vector<script_cache::Function> functions;
     std::vector<VarInfo> variables;
     std::vector<script_cache::EventHandler> event_handlers;
-    std::vector<char> code;
 };
 }

--- a/src/apps/engine/src/script_cache.h
+++ b/src/apps/engine/src/script_cache.h
@@ -1,0 +1,117 @@
+#pragma once
+#include "s_functab.h"
+
+#include <istream>
+#include <ostream>
+#include <vector>
+#include <zlib.h>
+
+namespace storm
+{
+namespace script_cache
+{
+struct Define
+{
+    std::string name;
+    uint32_t type;
+    uintptr_t value;
+};
+
+struct FunctionLocalVariable
+{
+    LocalVarInfo info;
+    bool is_extern;
+};
+
+struct Function
+{
+    FuncInfo info;
+    std::vector<FunctionLocalVariable> arguments;
+    std::vector<LocalVarInfo> local_variables;
+};
+
+struct EventHandler
+{
+    std::string event_name;
+    std::string function_name;
+};
+
+class Reader final
+{
+public:
+    explicit Reader(std::string_view data)
+        : data_(data), offset_(0)
+    {
+    }
+
+    template <typename T>
+    T *ReadData()
+    {
+        const auto size = sizeof(T);
+        if (offset_ + size > data_.size())
+        {
+            return nullptr;
+        }
+
+        auto address = data_.data() + offset_;
+        offset_ += size;
+        return address;
+    }
+
+    std::string_view ReadBytes()
+    {
+        auto size = ReadData<size_t>();
+        if (!size)
+        {
+            return {};
+        }
+
+        if (offset_ + *size > data_.size())
+        {
+            return {};
+        }
+
+        const auto address = data_.data() + offset_;
+        offset_ += *size;
+        return {address, *size};
+    }
+
+private:
+    std::string_view data_;
+    size_t offset_;
+};
+
+class Writer
+{
+public:
+    template <typename T>
+    void WriteData(const T &data)
+    {
+        const auto size = data_.size();
+        data_.resize(size + sizeof data);
+        std::memcpy(data_.data() + size, &data, sizeof(T));
+    }
+
+    void WriteBytes(std::string_view data)
+    {
+        WriteData(data.size());
+        const auto size = data_.size();
+        data_.resize(size + data.size());
+        std::memcpy(data_.data() + size, data.data(), data.size());
+    }
+
+private:
+    std::vector<char> data_;
+};
+}
+
+struct ScriptCache
+{
+    std::vector<script_cache::Define> defines;
+    std::vector<std::string> files;
+    std::vector<script_cache::Function> functions;
+    std::vector<VarInfo> variables;
+    std::vector<script_cache::EventHandler> event_handlers;
+    std::vector<char> code;
+};
+}

--- a/src/apps/engine/src/script_cache.h
+++ b/src/apps/engine/src/script_cache.h
@@ -43,7 +43,7 @@ public:
     }
 
     template <typename T>
-    T *ReadData()
+    const T *ReadData()
     {
         const auto size = sizeof(T);
         if (offset_ + size > data_.size())
@@ -53,7 +53,7 @@ public:
 
         auto address = data_.data() + offset_;
         offset_ += size;
-        return address;
+        return reinterpret_cast<const T *>(address);
     }
 
     std::string_view ReadBytes()
@@ -107,7 +107,7 @@ inline void ReadScriptData(Reader &reader, S_TOKEN_TYPE type, DATA *data)
     switch (type)
     {
     case VAR_INTEGER: {
-        const auto value = reader.ReadData<long>();
+        const auto value = reader.ReadData<int32_t>();
         data->Set(*value);
         break;
     }


### PR DESCRIPTION
Turned off by default, to turn on add ``use_cache = 1`` in ``script`` section of engine.ini. Creates compiled files in PROGRAM\\_\_cached\_\_ directory.