### PR TITLE
Replace few MSVC-only functions with std and fio

### DIFF
--- a/src/apps/engine/src/compiler.cpp
+++ b/src/apps/engine/src/compiler.cpp
@@ -1845,12 +1845,11 @@ bool COMPILER::Compile(SEGMENT_DESC &Segment, char *pInternalCode, uint32_t pInt
         _splitpath(Segment.name, nullptr, nullptr, file_name, nullptr);
         strcat_s(file_name, ".b");
         std::wstring FileNameW = utf8::ConvertUtf8ToWide(file_name);
-        fh = CreateFile(FileNameW.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS,
-                        FILE_ATTRIBUTE_NORMAL, nullptr);
-        if (fh != INVALID_HANDLE_VALUE)
+        auto fileS = fio->_CreateFile(file_name, std::ios::binary | std::ios::out);
+        if (fileS.is_open())
         {
-            WriteFile(fh, Segment.pCode, Segment.BCode_Program_size, (LPDWORD)&dwR, nullptr);
-            CloseHandle(fh);
+            fio->_WriteFile(fileS, Segment.pCode, Segment.BCode_Program_size);
+            fio->_CloseFile(fileS);
         }
     }
     return true;

--- a/src/apps/engine/src/core_impl.cpp
+++ b/src/apps/engine/src/core_impl.cpp
@@ -238,7 +238,7 @@ bool CoreImpl::Initialize()
 
 void CoreImpl::ProcessEngineIniFile()
 {
-    char String[_MAX_PATH];
+    char String[MAX_PATH];
 
     bEngineIniProcessed = true;
 

--- a/src/apps/engine/src/core_impl.h
+++ b/src/apps/engine/src/core_impl.h
@@ -144,7 +144,7 @@ class CoreImpl : public Core
     bool Initialized; // initialized flag (false at startup or after Reset())
     bool bEngineIniProcessed;
     HWND App_Hwnd;             // application handle
-    char gstring[_MAX_PATH]{}; // general purpose string
+    char gstring[MAX_PATH]{}; // general purpose string
     bool State_loading;
     bool bEnableTimeScale{};
 

--- a/src/apps/engine/src/data.cpp
+++ b/src/apps/engine/src/data.cpp
@@ -316,7 +316,7 @@ void DATA::Set(float value)
     }
     Data_type = VAR_FLOAT;
     fValue = value;
-    if (_isnan(fValue))
+    if (isnan(fValue))
         Error("NAN ERROR");
 }
 

--- a/src/apps/engine/src/file_service.cpp
+++ b/src/apps/engine/src/file_service.cpp
@@ -95,7 +95,15 @@ bool FILE_SERVICE::_ReadFile(std::fstream &fileS, void *s, std::streamsize count
 bool FILE_SERVICE::_FileOrDirectoryExists(const char *p)
 {
     std::filesystem::path path = std::filesystem::u8path(p);
-    return std::filesystem::exists(path);
+    auto ec = std::error_code{};
+    bool result = std::filesystem::exists(path, ec);
+    if (ec)
+    {
+        spdlog::error("Failed to to check if {} exists: {}", p, ec.message());
+        return false;
+    }
+
+    return result;
 }
 
 std::vector<std::string> FILE_SERVICE::_GetPathsOrFilenamesByMask(const char *sourcePath, const char *mask,

--- a/src/apps/engine/src/ifs.cpp
+++ b/src/apps/engine/src/ifs.cpp
@@ -1042,7 +1042,7 @@ void IFS::WriteString(const char *section_name, const char *key_name, const char
 void IFS::WriteLong(const char *section_name, const char *key_name, int32_t value)
 {
     char buffer[256];
-    _ltoa(value, buffer, 10);
+    sprintf(buffer, "%d", value);
     WriteString(section_name, key_name, buffer);
 }
 

--- a/src/apps/engine/src/token.h
+++ b/src/apps/engine/src/token.h
@@ -2,6 +2,7 @@
 
 #include <windows.h>
 #include <cstdint>
+#include <cstddef>
 
 enum S_TOKEN_TYPE
 {
@@ -160,10 +161,10 @@ class TOKEN
 {
     THLINE KeywordsHash[TOKENHASHTABLE_SIZE];
     S_TOKEN_TYPE eTokenType;
-    ptrdiff_t TokenDataBufferSize;
+    std::ptrdiff_t TokenDataBufferSize;
     int32_t Lines_in_token;
     char *pTokenData;
-    ptrdiff_t ProgramSteps[PROGRAM_STEPS_CACHE];
+    std::ptrdiff_t ProgramSteps[PROGRAM_STEPS_CACHE];
     int32_t ProgramStepsNum;
     char *Program;
     char *ProgramBase;
@@ -182,7 +183,7 @@ class TOKEN
     {
         return ProgramBase;
     };
-    ptrdiff_t GetProgramOffset();
+    std::ptrdiff_t GetProgramOffset();
 
     S_TOKEN_TYPE Get(bool bKeepData = false);
     S_TOKEN_TYPE ProcessToken(char *&pointer, bool bKeepData = false);
@@ -190,7 +191,7 @@ class TOKEN
     void CacheToken(const char *pointer);
     bool StepBack();
     int32_t SetTokenData(const char *pointer, bool bKeepControlSymbols = false);
-    ptrdiff_t SetNTokenData(const char *pointer, ptrdiff_t Data_size);
+    std::ptrdiff_t SetNTokenData(const char *pointer, std::ptrdiff_t Data_size);
     int32_t StopArgument(const char *pointer, bool bKeepControlSymbols = false);
     void StartArgument(char *&pointer, bool bKeepControlSymbols = false);
     const char *GetTypeName(S_TOKEN_TYPE code);

--- a/src/libs/common/include/message.h
+++ b/src/libs/common/include/message.h
@@ -160,7 +160,7 @@ class MESSAGE final
         index = 0;
     }
 
-    void Reset(const char *_format, va_list args)
+    void Reset(const char *_format, va_list &args)
     {
         index = 0;
         format_ = _format;

--- a/src/libs/island/src/island.cpp
+++ b/src/libs/island/src/island.cpp
@@ -673,7 +673,7 @@ bool ISLAND::CreateHeightMap(const std::string_view &pDir, const std::string_vie
             vSrc += vBoxCenter;
             vDst += vBoxCenter;
             float fRes = Trace(vSrc, vDst);
-            Assert(_isnan(fRes) == false);
+            Assert(isnan(fRes) == false);
             if (fRes <= 1.0f) // island ocean floor exist
             {
                 float fHeight = sqrtf(~(fRes * (vDst - vSrc)));

--- a/src/libs/lighter/src/l_geometry.cpp
+++ b/src/libs/lighter/src/l_geometry.cpp
@@ -466,7 +466,7 @@ bool LGeometry::Save()
             if (dir[p] == '\\')
             {
                 dir[p] = 0;
-                if (_access(dir, 0) == -1)
+                if (!fio->_FileOrDirectoryExists(dir))
                 {
                     if (!fio->_CreateDirectory(dir))
                     {

--- a/src/libs/location/src/location.cpp
+++ b/src/libs/location/src/location.cpp
@@ -530,7 +530,7 @@ int32_t Location::LoadStaticModel(const char *modelName, const char *tech, int32
         {
             auto &mtxx = *((CMatrix *)label.m);
             for (int32_t me = 0; me < 16; me++)
-                if (_isnan(mtxx.matrix[me]))
+                if (isnan(mtxx.matrix[me]))
                 {
                     core.Trace("Location: locator %s::%s in position have NaN value, reset it!", label.group_name,
                                label.name);

--- a/src/libs/renderer/src/s_device.h
+++ b/src/libs/renderer/src/s_device.h
@@ -25,7 +25,7 @@ struct D3DERRORS
 
 struct texpaths_t
 {
-    char str[_MAX_PATH];
+    char str[MAX_PATH];
 };
 
 struct STEXTURE

--- a/src/libs/renderer/src/screenshot.cpp
+++ b/src/libs/renderer/src/screenshot.cpp
@@ -29,7 +29,7 @@ void DX9RENDER::SaveCaptureBuffers()
     for (fi = iCaptureFrameIndex; fi < iCaptureFrameIndex + 10000; fi++)
     {
         sprintf_s(cFileName, "k3cap_%04d.tga", fi);
-        if (_access(cFileName, 0) == -1)
+        if (!fio->_FileOrDirectoryExists(cFileName))
             break;
     }
 

--- a/src/libs/sound_service/src/sound_service.cpp
+++ b/src/libs/sound_service/src/sound_service.cpp
@@ -851,13 +851,13 @@ void SoundService::SetActiveWithFade(const bool active)
 
     FMOD::ChannelGroup* mastergroup;
     CHECKFMODERR(system->getMasterChannelGroup(&mastergroup));
-    uint64_t parentclock;
+    unsigned long long parentclock; // type should match with getDSPClock param from fmod.hpp
     int rate;
     system->getSoftwareFormat(&rate, nullptr, nullptr);
     mastergroup->getDSPClock(nullptr, &parentclock);
 
     const auto dsp_clock_start = parentclock;
-    const auto dsp_clock_end = static_cast<uint64_t>(parentclock + fadeTimeInSeconds * rate);
+    const auto dsp_clock_end = static_cast<unsigned long long>(parentclock + fadeTimeInSeconds * rate);
 
     if (active)
     {

--- a/src/libs/worldmap/src/wdm_objects.h
+++ b/src/libs/worldmap/src/wdm_objects.h
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <vector>
+#include <optional>
 
 class WdmIslands;
 class WdmShip;

--- a/src/libs/worldmap/src/wdm_wind_ui.h
+++ b/src/libs/worldmap/src/wdm_wind_ui.h
@@ -12,6 +12,8 @@
 
 #include "wdm_interface_object.h"
 
+#include <optional>
+
 class WdmWindUI : public WdmInterfaceObject
 {
     // --------------------------------------------------------------------------------------------

--- a/src/libs/xinterface/src/string_service/str_service.cpp
+++ b/src/libs/xinterface/src/string_service/str_service.cpp
@@ -1292,19 +1292,6 @@ uint32_t _InterfaceCreateFolder(VS_STACK *pS)
     if (!pDat)
         return IFUNCRESULT_FAILED;
     const char *sFolderName = pDat->GetString();
-
-    // precreate directory
-    const char *pcCurPtr = sFolderName;
-    while ((pcCurPtr = strchr(pcCurPtr, '\\')) != nullptr)
-    {
-        const char tmpchr = pcCurPtr[0];
-        ((char *)pcCurPtr)[0] = 0;
-        std::wstring FolderNameW = utf8::ConvertUtf8ToWide(sFolderName);
-        CreateDirectory(FolderNameW.c_str(), nullptr);
-        ((char *)pcCurPtr)[0] = tmpchr;
-        pcCurPtr++;
-    }
-    // create self directory
     const int32_t nSuccess = fio->_CreateDirectory(sFolderName);
 
     pDat = (VDATA *)pS->Push();


### PR DESCRIPTION
This is few cherry-picks from my linux branch with:
- changing ptrdiff_t with std::ptrdiff_t.
- replacing few _* functions.
- replacing MSVC-only _ltoa with sprintf.
- add #include <optional>.
- restore few `unsigned long long`, because type should match with getDSPClock param from fmod.hpp.
- replacing `CreateFile`, `WriteFile`, `CloseHandle` with `fio` functions.
- removing unnecessary precreate directory, because `std::filesystem::create_directories` do it automatically.