### PR TITLE
[common] attributes: legacy proxy

### DIFF
--- a/src/libs/battle_interface/src/battle_command.cpp
+++ b/src/libs/battle_interface/src/battle_command.cpp
@@ -561,7 +561,7 @@ ATTRIBUTES *BICommandList::GetCurrentCommandAttribute() const
         auto *pA = pAR->GetAttributeClass(n);
         if (!pA)
             continue;
-        auto *const pcCommName = pA->GetAttribute("event");
+        const char *pcCommName = pA->GetAttribute("event");
         if (m_sCurrentCommandName == pcCommName)
             return pA;
     }

--- a/src/libs/battle_interface/src/interface_manager/mouse_pointer.cpp
+++ b/src/libs/battle_interface/src/interface_manager/mouse_pointer.cpp
@@ -66,7 +66,7 @@ void MousePointer::InitMouseCursors()
             {
                 m_aCursors[i].offset.x = pA->GetAttributeAsDword("xoffset", 0);
                 m_aCursors[i].offset.y = pA->GetAttributeAsDword("yoffset", 0);
-                m_aCursors[i].texture = pA->GetAttribute("texture");
+                m_aCursors[i].texture = to_string(pA->GetAttribute("texture"));
                 FULLRECT(m_aCursors[i].uv);
                 BIUtils::ReadRectFromAttr(pA, "uv", m_aCursors[i].uv, m_aCursors[i].uv);
             }

--- a/src/libs/battle_interface/src/land/battle_man_command.cpp
+++ b/src/libs/battle_interface/src/land/battle_man_command.cpp
@@ -71,7 +71,7 @@ int32_t BIManCommandList::CommandAdding()
         const int32_t pictureNum = pA->GetAttributeAsDword("picNum", 0);
         const int32_t selPictureNum = pA->GetAttributeAsDword("selPicNum", 0);
         const int32_t texNum = pA->GetAttributeAsDword("texNum", -1);
-        auto *const eventName = pA->GetAttribute("event");
+        const char *eventName = pA->GetAttribute("event");
         retVal +=
             AddToIconList(texNum, pictureNum, selPictureNum, -1, -1, eventName, -1, nullptr, pA->GetAttribute("note"));
     }
@@ -97,7 +97,7 @@ int32_t BIManCommandList::UserIconsAdding()
         const int32_t pictureNum = pA->GetAttributeAsDword("pic", 0);
         const int32_t selPictureNum = pA->GetAttributeAsDword("selpic", 0);
         const int32_t textureNum = pA->GetAttributeAsDword("tex", -1);
-        auto *const eventName = pA->GetAttribute("event");
+        const char *eventName = pA->GetAttribute("event");
         retVal += AddToIconList(textureNum, pictureNum, selPictureNum, -1, -1, eventName, i + 1,
                                 pA->GetAttribute("name"), pA->GetAttribute("note"));
     }
@@ -126,7 +126,7 @@ int32_t BIManCommandList::AbilityAdding()
         const int32_t textureNum = pA->GetAttributeAsDword("texNum", -1);
         // retVal += AddToIconList( textureNum, pictureNum, selPictureNum, -1, -1, pA->GetThisName(), i, null,
         // pA->GetAttribute("note") );
-        auto *const eventName = pA->GetAttribute("event");
+        const char *eventName = pA->GetAttribute("event");
         retVal += AddToIconList(textureNum, pictureNum, selPictureNum, -1, -1, eventName, -1, nullptr,
                                 pA->GetAttribute("note"));
     }

--- a/src/libs/battle_interface/src/land/battle_man_sign.h
+++ b/src/libs/battle_interface/src/land/battle_man_sign.h
@@ -171,7 +171,7 @@ inline bool BIManSign::FloatACompare(ATTRIBUTES *pA, const char *attrName, float
 
 inline bool BIManSign::StringACompare(ATTRIBUTES *pA, const char *attrName, std::string &sCompareVal)
 {
-    auto *const pVal = pA->GetAttribute(attrName);
+    const char *pVal = pA->GetAttribute(attrName);
     if (pVal == nullptr || sCompareVal == pVal)
         return false;
     sCompareVal = pVal;
@@ -180,7 +180,7 @@ inline bool BIManSign::StringACompare(ATTRIBUTES *pA, const char *attrName, std:
 
 inline bool BIManSign::FRectACompare(ATTRIBUTES *pA, const char *attrName, FRECT &rCompareVal)
 {
-    auto *const pVal = pA->GetAttribute(attrName);
+    const char *pVal = pA->GetAttribute(attrName);
     if (!pVal)
         return false;
     FRECT rTmp;

--- a/src/libs/battle_interface/src/message_icons.cpp
+++ b/src/libs/battle_interface/src/message_icons.cpp
@@ -196,7 +196,7 @@ bool MESSAGE_ICONS::InitData(entid_t host_eid, VDX9RENDER *_rs, ATTRIBUTES *pARo
     m_fBlindTimeUp = pARoot->GetAttributeAsFloat("BlindUpTime", .5f);
     m_fBlindTimeDown = pARoot->GetAttributeAsFloat("BlindDownTime", 1.f);
 
-    auto *const stmp = pARoot->GetAttribute("texture");
+    const char *stmp = pARoot->GetAttribute("texture");
     if (stmp != nullptr)
         m_idMsgIconsTexture = rs->TextureCreate(stmp);
     m_nHorzTextureSize = pARoot->GetAttributeAsDword("TexHSize", 1);

--- a/src/libs/battle_interface/src/sea/battle_ship_command.cpp
+++ b/src/libs/battle_interface/src/sea/battle_ship_command.cpp
@@ -327,7 +327,7 @@ int32_t BIShipCommandList::CommandAdding()
         const int32_t selPictureNum = pA->GetAttributeAsDword("selPicNum", 0);
         const int32_t cooldownPictureNum = pA->GetAttributeAsDword("cooldownPicNum", -1);
         const int32_t texNum = pA->GetAttributeAsDword("texNum", m_nCommandTextureNum);
-        auto *const eventName = pA->GetAttribute("event");
+        const char *eventName = pA->GetAttribute("event");
         retVal += AddToIconList(texNum, pictureNum, selPictureNum, cooldownPictureNum, -1, eventName, -1, nullptr,
                                 pA->GetAttribute("note"));
     }
@@ -412,7 +412,7 @@ int32_t BIShipCommandList::AbilityAdding()
         // retVal += AddToIconList( textureNum, pictureNum, selPictureNum, -1, -1, pA->GetThisName(), i, null,
         // pA->GetAttribute("note") );
         const int32_t cooldownPictureNum = pA->GetAttributeAsDword("cooldownPicNum", -1);
-        auto *const eventName = pA->GetAttribute("event");
+        const char *eventName = pA->GetAttribute("event");
         retVal += AddToIconList(textureNum, pictureNum, selPictureNum, cooldownPictureNum, -1, eventName, -1, nullptr,
                                 pA->GetAttribute("note"));
     }

--- a/src/libs/battle_interface/src/sea/island_descr.cpp
+++ b/src/libs/battle_interface/src/sea/island_descr.cpp
@@ -224,7 +224,7 @@ ISLAND_DESCRIBER::LOCATOR_DESCR *ISLAND_DESCRIBER::FindLocatorByName(char *name)
     {
         if (m_pLocators[i].pA == nullptr)
             continue;
-        auto *const curName = m_pLocators[i].pA->GetAttribute("name");
+        const char* curName = m_pLocators[i].pA->GetAttribute("name");
         if (curName != nullptr && storm::iEquals(name, curName))
             return &m_pLocators[i];
     }

--- a/src/libs/battle_interface/src/utils.cpp
+++ b/src/libs/battle_interface/src/utils.cpp
@@ -66,7 +66,7 @@ int32_t BIUtils::GetTextureFromAttr(VDX9RENDER *rs, ATTRIBUTES *pA, const char *
 {
     if (!rs || !pA)
         return -1;
-    auto *const sname = pA->GetAttribute(sAttrName);
+    const char *sname = pA->GetAttribute(sAttrName);
     if (!sname || sname[0] == 0)
         return -1;
     return rs->TextureCreate(sname);
@@ -77,7 +77,7 @@ bool BIUtils::ReadRectFromAttr(ATTRIBUTES *pA, const char *name, FRECT &rOut, FR
     rOut = rDefault;
     if (pA && name)
     {
-        auto *const pcStr = pA->GetAttribute(name);
+        const char *pcStr = pA->GetAttribute(name);
         if (pcStr)
         {
             sscanf(pcStr, "%f,%f,%f,%f", &rOut.left, &rOut.top, &rOut.right, &rOut.bottom);
@@ -92,7 +92,7 @@ bool BIUtils::ReadRectFromAttr(ATTRIBUTES *pA, const char *name, RECT &rOut, REC
     rOut = rDefault;
     if (pA && name)
     {
-        auto *const pcStr = pA->GetAttribute(name);
+        const char *pcStr = pA->GetAttribute(name);
         if (pcStr)
         {
             sscanf(pcStr, "%d,%d,%d,%d", &rOut.left, &rOut.top, &rOut.right, &rOut.bottom);
@@ -108,7 +108,7 @@ bool BIUtils::ReadPosFromAttr(ATTRIBUTES *pA, const char *name, float &fX, float
     fY = fYDef;
     if (pA && name)
     {
-        auto *const pcStr = pA->GetAttribute(name);
+        const char *pcStr = pA->GetAttribute(name);
         if (pcStr)
         {
             sscanf(pcStr, "%f,%f", &fX, &fY);

--- a/src/libs/battle_interface/src/world_map_interface/ship_command.cpp
+++ b/src/libs/battle_interface/src/world_map_interface/ship_command.cpp
@@ -49,7 +49,7 @@ int32_t WMShipCommandList::CommandAdding()
         const int32_t pictureNum = pA->GetAttributeAsDword("picNum", 0);
         const int32_t selPictureNum = pA->GetAttributeAsDword("selPicNum", 0);
         const int32_t texNum = pA->GetAttributeAsDword("texNum", -1);
-        auto *const eventName = pA->GetAttribute("event");
+        const char *eventName = pA->GetAttribute("event");
         retVal +=
             AddToIconList(texNum, pictureNum, selPictureNum, -1, -1, eventName, -1, nullptr, pA->GetAttribute("note"));
     }

--- a/src/libs/common/include/sd2_h/save_load.h
+++ b/src/libs/common/include/sd2_h/save_load.h
@@ -60,7 +60,7 @@ class CSaveLoad
         dwCurSize = 0;
 
         auto *pV = core.Event("SeaLoad_GetPointer", "sl", "seasave", -1);
-        auto *const pSave = pV->GetAClass()->GetAttribute("save");
+        const char *pSave = pV->GetAClass()->GetAttribute("save");
         uint32_t dwSize;
         char str[256];
         strncpy_s(str, pSave, 8);

--- a/src/libs/common/src/attributes.cpp
+++ b/src/libs/common/src/attributes.cpp
@@ -58,9 +58,10 @@ const std::string & ATTRIBUTES::GetValue() const
     return *value_;
 }
 
-const char * ATTRIBUTES::GetThisAttr() const
+ATTRIBUTES::LegacyProxy ATTRIBUTES::GetThisAttr() const
 {
-    return value_ ? value_->c_str() : nullptr;
+    return value_;
+
 }
 
 void ATTRIBUTES::SetName(const std::string_view &new_name)
@@ -114,38 +115,36 @@ ATTRIBUTES *ATTRIBUTES::VerifyAttributeClass(const std::string_view &name)
     return (pTemp) ? pTemp : CreateAttribute(name, "");
 }
 
-const char * ATTRIBUTES::GetAttribute(size_t n) const
+const char *ATTRIBUTES::GetAttributeName(size_t n) const
 {
-    if (n < attributes_.size() && attributes_[n]->value_) {
-        return attributes_[n]->value_->c_str();
-    }
-    else {
-        return nullptr;
-    }
-}
-
-const char * ATTRIBUTES::GetAttributeName(size_t n) const
-{
-    if (n < attributes_.size()) {
+    if (n < attributes_.size())
+    {
         return attributes_[n]->GetThisName();
     }
-    else {
+    else
+    {
         return nullptr;
     }
 }
 
-const char * ATTRIBUTES::GetAttribute(const std::string_view &name) const
+ATTRIBUTES::LegacyProxy ATTRIBUTES::GetAttribute(size_t n) const
+{
+    if (n < attributes_.size()) {
+        return attributes_[n]->value_;
+    }
+    else {
+        return {};
+    }
+}
+
+
+ATTRIBUTES::LegacyProxy ATTRIBUTES::GetAttribute(const std::string_view &name) const
 {
     for (const auto &attribute : attributes_)
         if (storm::iEquals(name, attribute->GetThisName())) {
-            if (attribute->value_) {
-                return attribute->value_->c_str();
-            }
-            else {
-                return nullptr;
-            }
+            return attribute->value_;
         }
-    return nullptr;
+    return {};
 }
 
 uint32_t ATTRIBUTES::GetAttributeAsDword(const char *name, uint32_t def) const

--- a/src/libs/core/src/compiler.cpp
+++ b/src/libs/core/src/compiler.cpp
@@ -5390,7 +5390,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
                     pV->Set("error");
                     break; /*return false;*/
                 }
-                pV->Set(rAP->GetThisAttr());
+                pV->Set(to_string(rAP->GetThisAttr()));
                 break;
             default:
                 SetError("invalid argument for STACK_PUSH");

--- a/src/libs/core/src/data.cpp
+++ b/src/libs/core/src/data.cpp
@@ -581,7 +581,7 @@ bool DATA::Get(const char *attribute_name, const char *&value)
     if (AttributesClass == nullptr)
         return false;
     // pAValue = Attributes.GetAttribute(attribute_name);
-    auto *const pAValue = AttributesClass->GetAttribute(attribute_name);
+    const char *pAValue = AttributesClass->GetAttribute(attribute_name);
     if (pAValue == nullptr)
         return false;
     value = pAValue;
@@ -1122,7 +1122,7 @@ bool DATA::Convert(S_TOKEN_TYPE type)
                 break;
             if (!AttributesClass->GetThisAttr())
                 break;
-            Set(AttributesClass->GetThisAttr());
+            Set(to_string(AttributesClass->GetThisAttr()));
             AttributesClass = nullptr;
             return true;
         case NUMBER:
@@ -1131,7 +1131,7 @@ bool DATA::Convert(S_TOKEN_TYPE type)
                 break;
             if (!AttributesClass->GetThisAttr())
                 break;
-            Set(AttributesClass->GetThisAttr());
+            Set(to_string(AttributesClass->GetThisAttr()));
             AttributesClass = nullptr;
             Data_type = VAR_INTEGER;
             lValue = 0;
@@ -1143,7 +1143,7 @@ bool DATA::Convert(S_TOKEN_TYPE type)
                 break;
             if (!AttributesClass->GetThisAttr())
                 break;
-            Set(AttributesClass->GetThisAttr());
+            Set(to_string(AttributesClass->GetThisAttr()));
             AttributesClass = nullptr;
             Data_type = VAR_FLOAT;
             fValue = 0.0f;
@@ -1676,7 +1676,7 @@ bool DATA::Plus(DATA *pV)
         case VAR_AREFERENCE:
             if (!pV->AttributesClass || !pV->AttributesClass->GetThisAttr())
                 break;
-            Set(sValue + pV->AttributesClass->GetThisAttr());
+            Set(sValue + to_string(pV->AttributesClass->GetThisAttr()));
             break;
         case VAR_INTEGER:
             Set(sValue + std::to_string(pV->lValue));

--- a/src/libs/core/src/internal_functions.cpp
+++ b/src/libs/core/src/internal_functions.cpp
@@ -2571,7 +2571,7 @@ void COMPILER::DumpAttributes(ATTRIBUTES *pA, int32_t level)
 
     for (uint32_t n = 0; n < pA->GetAttributesNum(); n++)
     {
-        DTrace("%s%s = %s", buffer, pA->GetAttributeName(n), pA->GetAttribute(n));
+        DTrace("%s%s = %s", buffer, pA->GetAttributeName(n), static_cast<const char*>(pA->GetAttribute(n)));
         DumpAttributes(pA->GetAttributeClass(pA->GetAttributeName(n)), level + 2);
     }
 }

--- a/src/libs/island/src/foam.cpp
+++ b/src/libs/island/src/foam.cpp
@@ -769,7 +769,7 @@ void CoastFoam::Save()
         return;
 
     char cKey[128], cSection[128], cTemp[1024];
-    const auto sID = std::string("resource\\foam\\locations\\") + AttributesPointer->GetAttribute("id") + ".ini";
+    const auto sID = std::string("resource\\foam\\locations\\") + to_string(AttributesPointer->GetAttribute("id")) + ".ini";
     fio->_DeleteFile(sID.c_str());
 
     auto pI = fio->CreateIniFile(sID.c_str(), false);
@@ -832,7 +832,7 @@ void CoastFoam::Load()
 {
     char cSection[256], cKey[256], cTemp[1024];
 
-    const auto sID = std::string("resource\\foam\\locations\\") + AttributesPointer->GetAttribute("id") + ".ini";
+    const auto sID = std::string("resource\\foam\\locations\\") + to_string(AttributesPointer->GetAttribute("id")) + ".ini";
     auto pI = fio->OpenIniFile(sID.c_str());
     if (!pI)
         return;

--- a/src/libs/island/src/island.cpp
+++ b/src/libs/island/src/island.cpp
@@ -457,7 +457,7 @@ bool ISLAND::CreateShadowMap(char *pDir, char *pName)
     }
 
     const std::filesystem::path path =
-        std::filesystem::path() / "resource" / "foam" / pDir / AttributesPointer->GetAttribute("LightingPath");
+        std::filesystem::path() / "resource" / "foam" / pDir / to_string(AttributesPointer->GetAttribute("LightingPath"));
     const std::string fileName = path.string() + pName + ".tga";
 
     fShadowMapSize = 2.0f * Max(vRealBoxSize.x, vRealBoxSize.z) + 1024.0f;
@@ -775,8 +775,8 @@ bool ISLAND::Mount(const std::string_view &fname, const std::string_view &fdir, 
     // <---
 
     model_id = EntityManager::CreateEntity("MODELR");
-    core.Send_Message(model_id, "ls", MSG_MODEL_SET_LIGHT_PATH, AttributesPointer->GetAttribute("LightingPath"));
-    core.Send_Message(model_id, "ls", MSG_MODEL_LOAD_GEO, (char *)pathStr.c_str());
+    core.Send_Message(model_id, "ls", MSG_MODEL_SET_LIGHT_PATH, static_cast<const char*>(AttributesPointer->GetAttribute("LightingPath")));
+    core.Send_Message(model_id, "ls", MSG_MODEL_LOAD_GEO, pathStr.c_str());
 
     // extract subobject(sea_bed) to another model
     auto *pModel = static_cast<MODEL *>(EntityManager::GetEntityPointer(model_id));

--- a/src/libs/location/src/character.cpp
+++ b/src/libs/location/src/character.cpp
@@ -21,6 +21,7 @@
 #include "core.h"
 #include "v_data.h"
 
+
 //============================================================================================
 
 #define CHARACTER_WAIT_AFTER_DEAD 6.0f //
@@ -1058,7 +1059,7 @@ void Character::SetSignTechnique()
     {
         return;
     }
-    const auto *pcTechniqueName = pATechnique->GetThisAttr();
+    const char *pcTechniqueName = pATechnique->GetThisAttr();
     if (signTechniqueName == pcTechniqueName)
         return;
     signTechniqueName = pcTechniqueName;

--- a/src/libs/location/src/location_script_lib.cpp
+++ b/src/libs/location/src/location_script_lib.cpp
@@ -72,7 +72,7 @@ inline bool CheckID(VDATA *vd, const char *id, bool &res)
     if (!a->HasValue()) {
         return true;
     }
-    res = storm::iEquals(a->GetThisAttr(), id);
+    res = storm::iEquals(to_string(a->GetThisAttr()), id);
     return true;
 }
 

--- a/src/libs/location/src/np_character.cpp
+++ b/src/libs/location/src/np_character.cpp
@@ -323,7 +323,7 @@ void NPCharacter::Update(float dltTime)
                 if (atr->HasValue())
                 {
                     location->Print(curPos + CVECTOR(0.0f, height, 0.0f), rad, line++, 1.0f, 0xffffff, 0.5f, "tmpl(%s)",
-                                    atr->GetThisAttr());
+                                    static_cast<const char*>(atr->GetThisAttr()));
                 }
             }
             atr = AttributesPointer->FindAClass(AttributesPointer, "chr_ai.type");
@@ -339,7 +339,7 @@ void NPCharacter::Update(float dltTime)
                 }
                 if (atr->HasValue())
                     location->Print(curPos + CVECTOR(0.0f, height, 0.0f), rad, line++, 1.0f, 0xffffff, 0.5f, "type(%s)",
-                                    atr->GetThisAttr());
+                                    static_cast<const char*>(atr->GetThisAttr()));
             }
             atr = AttributesPointer->FindAClass(AttributesPointer, "chr_ai.group");
             if (atr)

--- a/src/libs/locator/src/locator.cpp
+++ b/src/libs/locator/src/locator.cpp
@@ -94,8 +94,8 @@ void LOCATOR::LocateForI(VDATA *pData)
         return;
     }
     char sFileLocators[256];
-    auto *const pAFilesPath = pA->FindAClass(pA, "filespath.models");
-    sprintf_s(sFileLocators, "%s\\%s", (pAFilesPath) ? pAFilesPath->GetThisAttr() : "", pA->GetAttribute("locators"));
+    const auto *pAFilesPath = pA->FindAClass(pA, "filespath.models");
+    sprintf_s(sFileLocators, "%s\\%s", (pAFilesPath) ? static_cast<const char*>(pAFilesPath->GetThisAttr()) : "", static_cast<const char*>(pA->GetAttribute("locators")));
     rs->SetLoadTextureEnable(false);
     g = gs->CreateGeometry(sFileLocators, "", 0);
     rs->SetLoadTextureEnable(true);
@@ -122,7 +122,7 @@ void LOCATOR::LocateForI(VDATA *pData)
                             core.Trace("LOCATOR: no name");
                             continue;
                         }
-                        if (storm::iEquals(pAA->GetAttributeClass(n)->GetAttribute("name"), label.name))
+                        if (storm::iEquals(to_string(pAA->GetAttributeClass(n)->GetAttribute("name")), label.name))
                         {
                             pAA->GetAttributeClass(n)->SetAttributeUseFloat("x", label.m[3][0]);
                             pAA->GetAttributeClass(n)->SetAttributeUseFloat("y", label.m[3][1]);
@@ -143,8 +143,8 @@ void LOCATOR::LocateForI(VDATA *pData)
             auto *pARC = pAA->GetAttributeClass(n);
             if (!pARC->FindAClass(pARC, "x"))
             {
-                core.Trace("LOCATOR: Can't find locator with name: %s, geo: %s", pARC->GetAttribute("name"),
-                           pA->GetAttribute("locators"));
+                core.Trace("LOCATOR: Can't find locator with name: %s, geo: %s", static_cast<const char*>(pARC->GetAttribute("name")),
+                           static_cast<const char*>(pA->GetAttribute("locators")));
             }
         }
 

--- a/src/libs/rigging/src/script_func.cpp
+++ b/src/libs/rigging/src/script_func.cpp
@@ -68,7 +68,7 @@ uint32_t _GetAssembledString(VS_STACK *pS)
                         ATTRIBUTES *pA = pAttr->FindAClass(pAttr, &accessString[nAttrNameStart]);
                         if (pA != nullptr && pA->HasValue())
                         {
-                            const auto *writeStr = pA->GetThisAttr();
+                            const char *writeStr = pA->GetThisAttr();
                             switch (accessString[0])
                             {
                             case 's':

--- a/src/libs/sea_ai/src/ai_balls.cpp
+++ b/src/libs/sea_ai/src/ai_balls.cpp
@@ -110,7 +110,7 @@ void AIBalls::FireBallFromCamera()
 
 void AIBalls::AddBall(ATTRIBUTES *pABall)
 {
-    auto *const pBallName = pABall->GetAttribute("Type");
+    const char *pBallName = pABall->GetAttribute("Type");
     Assert(pBallName);
 
     uint32_t i;
@@ -143,7 +143,7 @@ void AIBalls::AddBall(ATTRIBUTES *pABall)
     pBall->fDirZ = sinf(fDir);
     pBall->pParticle = nullptr;
 
-    pBall->sBallEvent = pABall->GetAttribute("Event");
+    pBall->sBallEvent = to_string(pABall->GetAttribute("Event"));
     
     if (aBallTypes[i].sParticleName.size())
     {
@@ -364,7 +364,7 @@ uint32_t AIBalls::AttributeChanged(ATTRIBUTES *pAttributeChanged)
         fBallFlySoundDistance = AttributesPointer->GetAttributeAsFloat("BallFlySoundDistance");
         fBallFlySoundStereoMultiplier = AttributesPointer->GetAttributeAsFloat("BallFlySoundStereoMultiplyer");
         fDeltaTimeMultiplier = AttributesPointer->GetAttributeAsFloat("SpeedMultiply");
-        sTextureName = AttributesPointer->GetAttribute("Texture");
+        sTextureName = to_string(AttributesPointer->GetAttribute("Texture"));
         dwSubTexX = AttributesPointer->GetAttributeAsDword("SubTexX");
         dwSubTexY = AttributesPointer->GetAttributeAsDword("SubTexY");
 
@@ -390,7 +390,7 @@ uint32_t AIBalls::AttributeChanged(ATTRIBUTES *pAttributeChanged)
             ballType.fWeight = pAP->GetAttributeAsFloat("Weight");
 
             if (pAP->GetAttribute("Particle"))
-                ballType.sParticleName = pAP->GetAttribute("Particle");
+                ballType.sParticleName = to_string(pAP->GetAttribute("Particle"));
 
             aBallTypes.push_back(ballType);
 

--- a/src/libs/sea_ai/src/ai_fort.cpp
+++ b/src/libs/sea_ai/src/ai_fort.cpp
@@ -184,11 +184,11 @@ bool AIFort::AddFort(ATTRIBUTES *pIslandAP, ATTRIBUTES *pFortLabelAP, ATTRIBUTES
     auto *const pModelsDirAP = pIslandAP->FindAClass(pIslandAP, "filespath.models");
     Assert(pModelsDirAP);
 
-    auto *const pModelName = pModelAP->GetThisAttr();
+    const char *pModelName = pModelAP->GetThisAttr();
     Assert(pModelName);
-    auto *const pLocatorsName = pLocatorsAP->GetThisAttr();
+    const char *pLocatorsName = pLocatorsAP->GetThisAttr();
     Assert(pLocatorsName);
-    auto *const pModelsDir = pModelsDirAP->GetThisAttr();
+    const char *pModelsDir = pModelsDirAP->GetThisAttr();
     Assert(pModelsDir);
 
     auto *pFort = new AI_FORT(pFortLabelAP);

--- a/src/libs/sea_ai/src/ai_group.cpp
+++ b/src/libs/sea_ai/src/ai_group.cpp
@@ -29,15 +29,15 @@ void AIGroup::AddShip(entid_t eidShip, ATTRIBUTES *pACharacter, ATTRIBUTES *pASh
     AIShip *pShip = nullptr;
     if (const auto *pAMode = pACharacter->FindAClass(pACharacter, "Ship.Mode"))
     {
-        if (std::string("war") == pAMode->GetThisAttr())
+        if (std::string("war") == to_string(pAMode->GetThisAttr()))
         {
             pShip = new AIShipWar();
         }
-        else if (std::string("trade") == pAMode->GetThisAttr())
+        else if (std::string("trade") == to_string(pAMode->GetThisAttr()))
         {
             pShip = new AIShipTrade();
         }
-        else if (std::string("boat") == pAMode->GetThisAttr())
+        else if (std::string("boat") == to_string(pAMode->GetThisAttr()))
         {
             pShip = new AIShipBoat();
         }
@@ -49,7 +49,7 @@ void AIGroup::AddShip(entid_t eidShip, ATTRIBUTES *pACharacter, ATTRIBUTES *pASh
 
     CVECTOR vShipPos;
 
-    if (const auto event = GetCommanderACharacter()->GetAttribute("GroupShipPos_event"))
+    if (const char *event = GetCommanderACharacter()->GetAttribute("GroupShipPos_event"))
     {
         const auto result = core.Event(event, "lfffa", static_cast<uint32_t>(aGroupShips.size()), vInitGroupPos.x,
                                        vInitGroupPos.y, vInitGroupPos.z, pACharacter);
@@ -366,7 +366,7 @@ void AIGroup::ShipChangeGroup(ATTRIBUTES *pACharacter, const char *pGroupName)
     if (!pGOld)
     {
         core.Trace("AIGroup::ShipChangeGroup: Can't find group with character id = %s",
-                   pACharacter->GetAttribute("id"));
+                   static_cast<const char*>(pACharacter->GetAttribute("id")));
         return;
     }
     AIGroup *pGNew = FindOrCreateGroup(pGroupName);

--- a/src/libs/sea_ai/src/ai_sea_goods.cpp
+++ b/src/libs/sea_ai/src/ai_sea_goods.cpp
@@ -166,7 +166,7 @@ uint32_t AISeaGoods::AttributeChanged(ATTRIBUTES *pAttribute)
     }
     if (*pAttribute == "Model")
     {
-        sTmpModel = pAttribute->GetThisAttr();
+        sTmpModel = to_string(pAttribute->GetThisAttr());
         return 0;
     }
     if (*pAttribute == "Good")
@@ -191,7 +191,7 @@ uint32_t AISeaGoods::AttributeChanged(ATTRIBUTES *pAttribute)
 
     if (*pAttribute == "ModelsPath")
     {
-        sModelPath = pAttribute->GetThisAttr();
+        sModelPath = to_string(pAttribute->GetThisAttr());
         return 0;
     }
     if (*pAttribute == "DeleteGoodAnyway")

--- a/src/libs/sea_ai/src/sea_ai.cpp
+++ b/src/libs/sea_ai/src/sea_ai.cpp
@@ -147,7 +147,7 @@ uint64_t SEA_AI::ProcessMessage(MESSAGE &message)
         auto *pAIShip = AIShip::FindShip(pCharacter);
         if (!pAIShip)
         {
-            core.Trace("SeaAI err: SetSailState, can't find ship for character = %s", pCharacter->GetAttribute("id"));
+            core.Trace("SeaAI err: SetSailState, can't find ship for character = %s", static_cast<const char*>(pCharacter->GetAttribute("id")));
             return 0;
         }
         core.Send_Message(pAIShip->GetShipEID(), "lf", MSG_SHIP_SET_SAIL_STATE, fSailState);
@@ -424,7 +424,7 @@ void SEA_AI::AddShip(entid_t eidShip, ATTRIBUTES *pCharacter, ATTRIBUTES *pAShip
     Assert(pG);
 
     // search group
-    auto *const pGName = pG->GetAttribute("Name");
+    const char *pGName = pG->GetAttribute("Name");
     Assert(pGName);
 
     AIGroup::FindOrCreateGroup(pGName)->AddShip(eidShip, pCharacter, pAShip);
@@ -442,7 +442,7 @@ void SEA_AI::SetCompanionEnemy(ATTRIBUTES *pACharacter)
     // create and add to new group
     auto *pSeaAIG = pACharacter->FindAClass(pACharacter, "SeaAI.Group");
     Assert(pSeaAIG);
-    auto *const pGName = pSeaAIG->GetAttribute("Name");
+    const char *pGName = pSeaAIG->GetAttribute("Name");
     Assert(pGName);
 
     AIGroup::FindOrCreateGroup(pGName)->InsertShip(pS);

--- a/src/libs/ship/src/ship.cpp
+++ b/src/libs/ship/src/ship.cpp
@@ -1393,13 +1393,13 @@ bool SHIP::Mount(ATTRIBUTES *_pAShip)
 
     EntityManager::AddToLayer(SHIP_CANNON_TRACE, GetId(), iShipPriorityExecute);
 
-    auto *const pName = GetAShip()->GetAttribute("Name");
+    const char *pName = GetAShip()->GetAttribute("Name");
     if (!pName)
     {
         core.Trace("SHIP::Mount : Can't find attribute name in ShipsTypes %d, char: %d, %s, %s, %s",
                    GetAShip()->GetAttributeAsDword("index"), GetACharacter()->GetAttributeAsDword("index"),
-                   GetACharacter()->GetAttribute("name"), GetACharacter()->GetAttribute("lastname"),
-                   GetACharacter()->GetAttribute("id"));
+                   static_cast<const char*>(GetACharacter()->GetAttribute("name")), static_cast<const char*>(GetACharacter()->GetAttribute("lastname")),
+                   static_cast<const char*>(GetACharacter()->GetAttribute("id")));
         // GetACharacter()->Dump(GetACharacter(), 0);
         bMounted = false;
         return false;

--- a/src/libs/ship/src/ship_utils.cpp
+++ b/src/libs/ship/src/ship_utils.cpp
@@ -41,7 +41,7 @@ BOOL SHIP::BuildContour(CVECTOR *vContour, int32_t &iNumVContour)
     }
     else
     {
-        core.Trace("SHIP: Up trace error, ship %s", GetAShip()->GetAttribute("Name"));
+        core.Trace("SHIP: Up trace error, ship %s", static_cast<const char*>(GetAShip()->GetAttribute("Name")));
         bDefaultContour = true;
         Beep(1000, 200);
     }
@@ -55,7 +55,7 @@ BOOL SHIP::BuildContour(CVECTOR *vContour, int32_t &iNumVContour)
         vP2 = vSrc + fRes * (vDst - vSrc);
     else
     {
-        core.Trace("SHIP: Down trace error, ship %s", GetAShip()->GetAttribute("Name"));
+        core.Trace("SHIP: Down trace error, ship %s", static_cast<const char*>(GetAShip()->GetAttribute("Name")));
         bDefaultContour = true;
         Beep(1000, 200);
     }

--- a/src/libs/teleport/src/teleport.cpp
+++ b/src/libs/teleport/src/teleport.cpp
@@ -228,7 +228,7 @@ void TMPTELEPORT::SetShowData(ATTRIBUTES *pA)
 
     for (auto i = 0; i < m_nStrQuantity; i++)
     {
-        auto *const tmpStr = pA->GetAttribute(i);
+        const char *tmpStr = pA->GetAttribute(i);
         m_descrArray[i].name = nullptr;
         m_descrArray[i].num = i;
         if (tmpStr == nullptr)
@@ -286,8 +286,8 @@ bool FINDFILESINTODIRECTORY::Init()
 {
     if (AttributesPointer)
     {
-        auto *const dirName = AttributesPointer->GetAttribute("dir");
-        auto *const maskName = AttributesPointer->GetAttribute("mask");
+        const char *dirName = AttributesPointer->GetAttribute("dir");
+        const char *maskName = AttributesPointer->GetAttribute("mask");
         const char *curMask;
         if (maskName)
         {
@@ -317,7 +317,7 @@ bool FINDDIALOGNODES::Init()
 {
     if (AttributesPointer)
     {
-        auto *const fileName = AttributesPointer->GetAttribute("file");
+        const char *fileName = AttributesPointer->GetAttribute("file");
         auto *pA = AttributesPointer->CreateSubAClass(AttributesPointer, "nodelist");
         if (fileName && pA)
         {

--- a/src/libs/weather/src/rain.cpp
+++ b/src/libs/weather/src/rain.cpp
@@ -594,7 +594,7 @@ uint32_t RAIN::AttributeChanged(ATTRIBUTES *pAttribute)
         }
         if (*pAttribute == "DropsTexture")
         {
-            sDropsTexture = pAttribute->GetThisAttr();
+            sDropsTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
     }
@@ -607,7 +607,7 @@ uint32_t RAIN::AttributeChanged(ATTRIBUTES *pAttribute)
         }
         if (*pAttribute == "Texture")
         {
-            sRainbowTexture = pAttribute->GetThisAttr();
+            sRainbowTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
     }

--- a/src/libs/weather/src/sky.cpp
+++ b/src/libs/weather/src/sky.cpp
@@ -456,25 +456,25 @@ uint32_t SKY::AttributeChanged(ATTRIBUTES *pAttribute)
 
     if (*pAttribute == "techSky")
     {
-        sTechSky = pAttribute->GetThisAttr();
+        sTechSky = to_string(pAttribute->GetThisAttr());
         return 0;
     }
 
     if (*pAttribute == "techSkyBlend")
     {
-        sTechSkyBlend = pAttribute->GetThisAttr();
+        sTechSkyBlend = to_string(pAttribute->GetThisAttr());
         return 0;
     }
 
     if (*pAttribute == "techSkyAlpha")
     {
-        sTechSkyBlendAlpha = pAttribute->GetThisAttr();
+        sTechSkyBlendAlpha = to_string(pAttribute->GetThisAttr());
         return 0;
     }
 
     if (*pAttribute == "techSkyFog")
     {
-        sTechSkyFog = pAttribute->GetThisAttr();
+        sTechSkyFog = to_string(pAttribute->GetThisAttr());
         return 0;
     }
 
@@ -523,13 +523,13 @@ void SKY::FillSkyDirArray(ATTRIBUTES *pAttribute)
             {
                 const auto i = atol(&attrName[1]);
                 if (i < q)
-                    aSkyDirArray[i] = pAttribute->GetAttribute(n);
+                    aSkyDirArray[i] = to_string(pAttribute->GetAttribute(n));
             }
         }
     }
     else
     {
-        aSkyDirArray[0] = pAttribute->GetAttribute(static_cast<size_t>(0U));
+        aSkyDirArray[0] = to_string(pAttribute->GetAttribute(0U));
     }
     fTimeFactor = static_cast<float>(atof(pAttribute->GetThisAttr()));
     if (fTimeFactor < 0.f || fTimeFactor > 24.f)

--- a/src/libs/weather/src/sun_glow.cpp
+++ b/src/libs/weather/src/sun_glow.cpp
@@ -414,27 +414,27 @@ uint32_t SUNGLOW::AttributeChanged(ATTRIBUTES *pAttribute)
         }
         if (*pAttribute == "SunTexture")
         {
-            Glow.sSunTexture = pAttribute->GetThisAttr();
+            Glow.sSunTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "MoonTexture")
         {
-            Glow.sMoonTexture = pAttribute->GetThisAttr();
+            Glow.sMoonTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "GlowTexture")
         {
-            Glow.sGlowTexture = pAttribute->GetThisAttr();
+            Glow.sGlowTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "TechniqueZ")
         {
-            Glow.sTechniqueZ = pAttribute->GetThisAttr();
+            Glow.sTechniqueZ = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "TechniqueNoZ")
         {
-            Glow.sTechniqueNoZ = pAttribute->GetThisAttr();
+            Glow.sTechniqueNoZ = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "DecayTime")
@@ -454,12 +454,12 @@ uint32_t SUNGLOW::AttributeChanged(ATTRIBUTES *pAttribute)
         }
         if (*pAttribute == "Texture")
         {
-            Flares.sTexture = pAttribute->GetThisAttr();
+            Flares.sTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "Technique")
         {
-            Flares.sTechnique = pAttribute->GetThisAttr();
+            Flares.sTechnique = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "TexSizeX")
@@ -485,12 +485,12 @@ uint32_t SUNGLOW::AttributeChanged(ATTRIBUTES *pAttribute)
         bHaveOverflow = true;
         if (*pAttribute == "Texture")
         {
-            Overflow.sTexture = pAttribute->GetThisAttr();
+            Overflow.sTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "Technique")
         {
-            Overflow.sTechnique = pAttribute->GetThisAttr();
+            Overflow.sTechnique = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "Size")
@@ -516,7 +516,7 @@ uint32_t SUNGLOW::AttributeChanged(ATTRIBUTES *pAttribute)
         bHaveReflection = true;
         if (*pAttribute == "Texture")
         {
-            Reflection.sTexture = pAttribute->GetThisAttr();
+            Reflection.sTexture = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         if (*pAttribute == "Size")
@@ -536,7 +536,7 @@ uint32_t SUNGLOW::AttributeChanged(ATTRIBUTES *pAttribute)
         }
         if (*pAttribute == "Technique")
         {
-            Reflection.sTechnique = pAttribute->GetThisAttr();
+            Reflection.sTechnique = to_string(pAttribute->GetThisAttr());
             return 0;
         }
         return 0;

--- a/src/libs/worldmap/src/wdm_wind_ui.cpp
+++ b/src/libs/worldmap/src/wdm_wind_ui.cpp
@@ -88,10 +88,10 @@ void WdmWindUI::SetAttributes(ATTRIBUTES *apnt)
     if (ap)
     {
         // Font
-        auto *s = ap->GetAttribute("font");
+        const char *s = ap->GetAttribute("font");
         if (s && s[0])
             dateFont = wdmObjects->wm->GetRS()->LoadFont(s);
-        const auto *coordinate = ap->GetAttribute("coordinate");
+        const char *coordinate = ap->GetAttribute("coordinate");
         if (coordinate != nullptr)
         {
             strcpy_s(wdmObjects->stCoordinate, coordinate);
@@ -126,7 +126,7 @@ void WdmWindUI::SetAttributes(ATTRIBUTES *apnt)
     if (ap)
     {
         // Font
-        auto *texName = ap->GetAttribute("texName");
+        const char *texName = ap->GetAttribute("texName");
         if (texName)
         {
             const auto newTxNationFlag = wdmObjects->rs->TextureCreate(texName);

--- a/src/libs/worldmap/src/world_map.cpp
+++ b/src/libs/worldmap/src/world_map.cpp
@@ -225,7 +225,7 @@ bool WorldMap::Init()
         wdmObjects->stormBrnDistMax =
             AttributesPointer->GetAttributeAsFloat("stormBrnDistMax", wdmObjects->stormBrnDistMax);
         wdmObjects->stormZone = AttributesPointer->GetAttributeAsFloat("stormZone", wdmObjects->stormZone);
-        auto *const s = AttributesPointer->GetAttribute("debug");
+        const char *s = AttributesPointer->GetAttribute("debug");
         wdmObjects->isDebug = s && (storm::iEquals(s, "true"));
         saveData = AttributesPointer->CreateSubAClass(AttributesPointer, "encounters");
         wdmObjects->resizeRatio = AttributesPointer->GetAttributeAsFloat("resizeRatio", wdmObjects->resizeRatio);
@@ -335,13 +335,13 @@ bool WorldMap::Init()
             }
             if (storm::iEquals(type, "Warring") && modelName && modelName[0])
             {
-                auto *const attacked = a->GetAttribute("attacked");
+                const char *attacked = a->GetAttribute("attacked");
                 if (attacked)
                 {
                     auto *a1 = saveData->FindAClass(saveData, attacked);
                     if (a1)
                     {
-                        auto *const modelName1 = a1->GetAttribute("modelName");
+                        const char *modelName1 = a1->GetAttribute("modelName");
                         if (modelName1 && modelName1[0])
                         {
                             if (!CreateWarringShips(modelName, modelName1, -1.0f, a, a1))
@@ -474,7 +474,7 @@ void WorldMap::Realize(uint32_t delta_time)
 #endif
     }
     //
-    auto *tmp = aDate->GetAttribute("sec");
+    const char *tmp = aDate->GetAttribute("sec");
     if (tmp)
         strcpy_s(wdmObjects->attrSec, tmp);
     tmp = aDate->GetAttribute("min");

--- a/src/libs/xinterface/src/back_scene/back_scene.cpp
+++ b/src/libs/xinterface/src/back_scene/back_scene.cpp
@@ -560,7 +560,7 @@ void InterfaceBackScene::CreateMenuList(int32_t nStartIndex, ATTRIBUTES *pAMenu)
             continue;
         if (!FindLocator(pA->GetAttribute("locname"), &mtx, nullptr, nullptr))
         {
-            core.Trace("Warning! Interface Back scene: Can`t find locator %s", pA->GetAttribute("locname"));
+            core.Trace("Warning! Interface Back scene: Can`t find locator %s", static_cast<const char*>(pA->GetAttribute("locname")));
         }
         auto *pMD = new MenuDescr;
         Assert(pMD);

--- a/src/libs/xinterface/src/info_handler.cpp
+++ b/src/libs/xinterface/src/info_handler.cpp
@@ -138,8 +138,8 @@ bool InfoHandler::DoPreOut()
         nOutOffset = AttributesPointer->GetAttributeAsDword("offset", m_rs->CharHeight(0));
     }
 
-    auto *const picTexureFile = AttributesPointer->GetAttribute("picfilename");
-    auto *const picBackTexureFile = AttributesPointer->GetAttribute("picbackfilename");
+    const char *picTexureFile = AttributesPointer->GetAttribute("picfilename");
+    const char *picBackTexureFile = AttributesPointer->GetAttribute("picbackfilename");
     const uint32_t TMP_VERTEX_FORMAT = (D3DFVF_XYZRHW | D3DFVF_DIFFUSE | D3DFVF_TEX1 | D3DFVF_TEXTUREFORMAT2);
     struct TMP_VERTEX
     {

--- a/src/libs/xinterface/src/nodes/xi_edit_box.cpp
+++ b/src/libs/xinterface/src/nodes/xi_edit_box.cpp
@@ -160,7 +160,7 @@ int CXI_EDITBOX::CommandExecute(int wActCode)
                 break;
             char param[256];
             param[0] = 0;
-            auto *const tmpstr = pA->GetAttribute("strdata");
+            const char *tmpstr = pA->GetAttribute("strdata");
             switch (m_alpha[m_bUpChrRegistrOffset + m_nCurAlphaNum])
             {
             case '*':

--- a/src/libs/xinterface/src/nodes/xi_four_img.cpp
+++ b/src/libs/xinterface/src/nodes/xi_four_img.cpp
@@ -336,7 +336,7 @@ void CXI_FOURIMAGE::LoadIni(INIFILE *ini1, const char *name1, INIFILE *ini2, con
             }
             for (i = 0; i < m_nTexturesQuantity; i++)
             {
-                auto *const stmp = pA->GetAttribute(i);
+                const char *stmp = pA->GetAttribute(i);
                 if (stmp == nullptr)
                     m_sGroupName[i] = nullptr;
                 else
@@ -372,7 +372,7 @@ void CXI_FOURIMAGE::LoadIni(INIFILE *ini1, const char *name1, INIFILE *ini2, con
                         pPictureService->GetImageNum(m_sGroupName[m_twoTexID[i]], pAttrTmp->GetAttribute("img2"));
                 else
                     m_twoImgID[i] = -1;
-                auto *tmps = pAttrTmp->GetAttribute("str1");
+                const char *tmps = pAttrTmp->GetAttribute("str1");
                 if (tmps != nullptr && *tmps == '#')
                 {
                     const auto len = strlen(tmps);

--- a/src/libs/xinterface/src/nodes/xi_keychanger.cpp
+++ b/src/libs/xinterface/src/nodes/xi_keychanger.cpp
@@ -121,7 +121,7 @@ void CXI_KEYCHANGER::SetChoosingControls(ATTRIBUTES *pA)
         sprintf_s(contrlName, "cntrl_%d", i);
         m_pbControlsStick[i] = false;
         m_pControlsID[i] = core.Controls->CreateControl(contrlName);
-        auto *const keyCode = pA->GetAttribute(i);
+        const char *keyCode = pA->GetAttribute(i);
         if (keyCode != nullptr)
         {
             core.Controls->MapControl(m_pControlsID[i], atoi(keyCode));

--- a/src/libs/xinterface/src/nodes/xi_pc_edit_box.cpp
+++ b/src/libs/xinterface/src/nodes/xi_pc_edit_box.cpp
@@ -290,7 +290,7 @@ void CXI_PCEDITBOX::UpdateString(std::string &str)
     }
     if (!pA)
         return;
-    str = pA->GetAttribute("str");
+    str = to_string(pA->GetAttribute("str"));
     int strLength = utf8::Utf8StringLength(str.c_str());
     if (m_nEditPos < 0)
         m_nEditPos = strLength;

--- a/src/libs/xinterface/src/nodes/xi_scrollbar.cpp
+++ b/src/libs/xinterface/src/nodes/xi_scrollbar.cpp
@@ -125,7 +125,7 @@ void CXI_SCROLLBAR::Draw(bool bSelected, uint32_t Delta_Time)
             pA = pA->GetAttributeClass(m_nodeName);
             if (pA)
             {
-                auto *const pcStr = pA->GetAttribute("str");
+                const char *pcStr = pA->GetAttribute("str");
                 if (pcStr)
                 {
                     m_rs->ExtPrint(m_nFontID, m_dwFontColor, 0, PR_ALIGN_CENTER, true, m_fFontScale, m_screenSize.x,

--- a/src/libs/xinterface/src/nodes/xi_v_img_scroll.cpp
+++ b/src/libs/xinterface/src/nodes/xi_v_img_scroll.cpp
@@ -435,7 +435,7 @@ void CXI_VIMAGESCROLL::LoadIni(INIFILE *ini1, const char *name1, INIFILE *ini2, 
     {
         // get special technique name and color
         m_dwSpecTechniqueARGB = pAttribute->GetAttributeAsDword("SpecTechniqueColor");
-        auto *const sTechnique = pAttribute->GetAttribute("SpecTechniqueName");
+        const char *sTechnique = pAttribute->GetAttribute("SpecTechniqueName");
         if (sTechnique != nullptr)
         {
             const auto len = strlen(sTechnique) + 1;
@@ -476,7 +476,7 @@ void CXI_VIMAGESCROLL::LoadIni(INIFILE *ini1, const char *name1, INIFILE *ini2, 
                 }
                 for (i = 0; i < m_nGroupQuantity; i++)
                 {
-                    auto *const stmp = pA->GetAttribute(i);
+                    const char *stmp = pA->GetAttribute(i);
                     if (stmp == nullptr)
                         continue;
                     const auto len = strlen(stmp) + 1;

--- a/src/libs/xinterface/src/xinterface.cpp
+++ b/src/libs/xinterface/src/xinterface.cpp
@@ -410,10 +410,9 @@ void XINTERFACE::Realize(uint32_t)
             for (auto i = 0; i < m_nStringQuantity; i++)
                 if (m_stringes[i].bUsed)
                 {
-                    auto *tmps = tmpAttr->GetAttribute(m_stringes[i].sStringName);
                     pRenderService->ExtPrint(m_stringes[i].fontNum, m_stringes[i].dwColor, 0, m_stringes[i].eAlignment,
                                              true, m_stringes[i].fScale, dwScreenWidth, dwScreenHeight, m_stringes[i].x,
-                                             m_stringes[i].y, "%s", tmpAttr->GetAttribute(m_stringes[i].sStringName));
+                                             m_stringes[i].y, "%s", static_cast<const char*>(tmpAttr->GetAttribute(m_stringes[i].sStringName)));
                 }
     }
 
@@ -2636,7 +2635,7 @@ uint32_t XINTERFACE::AttributeChanged(ATTRIBUTES *patr)
         if (storm::iEquals(patr->GetThisName(), "pic"))
         {
             STORM_DELETE(pImList->sPicture);
-            if (patr->GetThisAttr() != nullptr)
+            if (patr->HasValue())
             {
                 const auto len = strlen(patr->GetThisAttr()) + 1;
                 if ((pImList->sPicture = new char[len]) == nullptr)
@@ -2655,7 +2654,7 @@ uint32_t XINTERFACE::AttributeChanged(ATTRIBUTES *patr)
             if (pImList->sImageListName != nullptr)
                 pPictureService->ReleaseTextureID(pImList->sImageListName);
             STORM_DELETE(pImList->sImageListName);
-            if (patr->GetThisAttr() != nullptr)
+            if (patr->HasValue())
             {
                 const auto len = strlen(patr->GetThisAttr()) + 1;
                 if ((pImList->sImageListName = new char[len]) == nullptr)

--- a/src/libs/xinterface/testsuite/options_parser.cpp
+++ b/src/libs/xinterface/testsuite/options_parser.cpp
@@ -47,7 +47,6 @@ class TestStringCodec : public VSTRING_CODEC
 
 TEST_CASE("Remove carriage return characters from string", "[xinterface]")
 {
-    using namespace storm;
     using namespace std::string_literals;
 
     auto value = "Hello,\r\nWorld!\r\n"s;
@@ -59,7 +58,6 @@ TEST_CASE("Remove carriage return characters from string", "[xinterface]")
 
 TEST_CASE("Parse options", "[xinterface]")
 {
-    using namespace storm;
     using namespace std::string_literals;
     using namespace std::string_view_literals;
 
@@ -75,11 +73,11 @@ TEST_CASE("Parse options", "[xinterface]")
 
         CHECK(attribute.GetAttributesNum() == 2);
 
-        const auto title_attribute = attribute.GetAttribute("title");
+        const char *title_attribute = attribute.GetAttribute("title");
         REQUIRE(title_attribute != nullptr);
         CHECK(title_attribute == "My title"sv);
 
-        const auto text_attribute = attribute.GetAttribute("text");
+        const char *text_attribute = attribute.GetAttribute("text");
         REQUIRE(text_attribute != nullptr);
         CHECK(text_attribute == "Hello, World!"sv);
     }
@@ -94,11 +92,11 @@ TEST_CASE("Parse options", "[xinterface]")
 
         CHECK(attribute.GetAttributesNum() == 2);
 
-        const auto title_attribute = attribute.GetAttribute("title");
+        const char *title_attribute = attribute.GetAttribute("title");
         REQUIRE(title_attribute != nullptr);
         CHECK(title_attribute == "My title"sv);
 
-        const auto text_attribute = attribute.GetAttribute("text");
+        const char *text_attribute = attribute.GetAttribute("text");
         REQUIRE(text_attribute != nullptr);
         CHECK(text_attribute == "Hello, World!"sv);
     }
@@ -117,19 +115,21 @@ TEST_CASE("Parse options", "[xinterface]")
         storm::parseOptions(source, attribute);
 
         CHECK(attribute.GetAttributesNum() == 2);
-        CHECK(attribute.GetAttribute("title") == "Inform the governor about the French attack."sv);
+        const char *title_attribute = attribute.GetAttribute("title");
+        REQUIRE(title_attribute != nullptr);
+        CHECK(title_attribute == "Inform the governor about the French attack."sv);
 
-        const auto text_attribute = attribute.GetAttributeClass("text");
+        const auto *text_attribute = attribute.GetAttributeClass("text");
         REQUIRE(text_attribute != nullptr);
         CHECK(text_attribute->GetAttributesNum() == 2);
 
-        const auto t1 = text_attribute->GetAttribute("t1");
+       const char *t1 = text_attribute->GetAttribute("t1");
         REQUIRE(t1 != nullptr);
         CHECK(
             t1 ==
             "Malcolm was right about spotting French near #sisland_Oxbay#. A war fleet is upon #sOxbay# port! I had better get away before I am detected and destroyed with the rest of the English here."sv);
 
-        const auto t2 = text_attribute->GetAttribute("t2");
+        const char *t2 = text_attribute->GetAttribute("t2");
         REQUIRE(t2 != nullptr);
         CHECK(
             t2 ==


### PR DESCRIPTION
this prevents `std::string` to be constructed from `nullptr` by using a proxy abstraction with small overhead