### PR TITLE
Fix mimalloc_fun for Windows and Linux

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -127,7 +127,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     }
     mi_register_output(mimalloc_fun, nullptr);
     mi_option_set(mi_option_show_errors, 1);
-    mi_option_set(mi_option_show_stats, 1);
+    mi_option_set(mi_option_show_stats, 0);
     mi_option_set(mi_option_eager_commit, 1);
     mi_option_set(mi_option_eager_region_commit, 1);
     mi_option_set(mi_option_large_os_pages, 1);


### PR DESCRIPTION
Old behavior.
In Windows and Linux `mimalloc_fun` will be called >= 2 times:
1) Initialization: will remove old file and will keep alive `mimalloc_log_path` until you exit.
2) Not sure, but I did not see in Windows any other messages, but it's totally possible and I have at least one in Linux.
3) When you press exit you: firstly go to the end of main `return EXIT_SUCCESS;` and after that calling `mimalloc_fun`

In Windows after exiting main and running `mimalloc_fun` I got `mimalloc_log_path.empty() == true`: it remove all previous messages and write only last block of messages.
In Linux after exiting main and running `mimalloc_fun` I got `mimalloc_log_path.empty() == false`, but it contain random non ascii chars => it will not remove previous messages in mimalloc.log but will create random non ascii filename in current folder.

```
q@i5-3450:~/git/sd-teho-public$ ls
''$'\036\224\017\311\361''`'$'\357\235\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\005'
 engine-1_d3d9.log
 engine-1.dxvk-cache
 engine.ini
 LICENSE
''$'\274\265''N'$'\t\030''F'$'\343''v'$'\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\337\005'
 PROGRAM
 README.md
 resource
 SAVE
 shaders
''$'\340'''$'\f\213\004'
q@i5-3450:~/git/sd-teho-public$
```

New behavior.
1. For Windows and Linux `mimalloc_fun` will get "init" arg only once in main when calling `mi_register_output` and then it will remove old  mimalloc.log.
2. All other calls will write to mimalloc.log without removing it.
3. I have to remove `static` in `GetStashPath()` and from `static std::filesystem::path mimalloc_log_path;` to not get random non ascii in Linux.