### PR TITLE
[core] token: fix incorrect debug source line

### DIFF
--- a/src/libs/core/src/token.cpp
+++ b/src/libs/core/src/token.cpp
@@ -1117,7 +1117,10 @@ S_TOKEN_TYPE TOKEN::ProcessToken(char *&pointer, bool bKeepData)
             sym = *Program;
             Program += utf8::u8_inc(Program);
             if (sym == '\r' || sym == '\n')
+            {
+                --Program;
                 break;
+            }
         } while (sym != 0);
         SetNTokenData(pBase, Program - pBase);
         break;


### PR DESCRIPTION
 - in files with '\n' ending (not '\r\n') this caused linefeed token to be omitted