### PR TITLE
fix crash on Ship_HullDamage call (event_name "ShpHullDamage")

### DIFF
--- a/src/libs/ship/src/ship.cpp
+++ b/src/libs/ship/src/ship.cpp
@@ -1760,8 +1760,8 @@ float SHIP::Cannon_Trace(int32_t iBallOwner, const CVECTOR &vSrc, const CVECTOR 
                 {
                     const CVECTOR v1 = vSrc + fRes * (vDst - vSrc);
 
-                    VDATA *pV = core.Event(SHIP_HULL_DAMAGE, "llffffaas", SHIP_HULL_TOUCH_BALL, pM->iHullNum, v1.x,
-                                           v1.y, v1.z, pM->fDamage, GetACharacter(), iBallOwner, pM->pNode->GetName());
+                    VDATA *pV = core.Event(SHIP_HULL_DAMAGE, "llffffas", SHIP_HULL_TOUCH_BALL, pM->iHullNum, v1.x,
+                                           v1.y, v1.z, pM->fDamage, GetACharacter(), pM->pNode->GetName());
                     if (pV)
                     {
                         pM->fDamage = Clamp(pV->GetFloat());


### PR DESCRIPTION
How to reproduce crash:
Load attached save and fight with enemy in sea.
[Open_sea-SAVE.zip](https://github.com/storm-devs/storm-engine/files/8732851/Open_sea-SAVE.zip)
Crash sometimes happens when cannonballs hit your ship.

How it looks like in debugger:
![unknown](https://user-images.githubusercontent.com/1950719/169372655-7498309b-9089-4ade-bdc4-f086da674c41.png)

