### PR TITLE
Replace WinAPI Performance calls to SDL calls

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -213,7 +213,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
     core_private->InitBase();
 
     // Message loop
-    auto dwOldTime = GetTickCount();
+    auto dwOldTime = SDL_GetTicks();
 
     isRunning = true;
     while (isRunning)
@@ -226,7 +226,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR szCmdLine,
             if (dwMaxFPS)
             {
                 const auto dwMS = 1000u / dwMaxFPS;
-                const auto dwNewTime = GetTickCount();
+                const auto dwNewTime = SDL_GetTicks();
                 if (dwNewTime - dwOldTime < dwMS)
                     continue;
                 dwOldTime = dwNewTime;

--- a/src/libs/common/include/defines.h
+++ b/src/libs/common/include/defines.h
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <cstring>
 
+#include <SDL2/SDL.h>
+
 namespace TOREMOVE
 {
 inline uint32_t HashNoCase(const char *str)
@@ -75,19 +77,8 @@ constexpr float PIm2 = (PI * 2.0f);
 constexpr float PId2 = (PI / 2.0f);
 constexpr float PId4 = (PI / 4.0f);
 
-#define RDTSC_B(x)                                                                                                     \
-    {                                                                                                                  \
-        LARGE_INTEGER li;                                                                                              \
-        QueryPerformanceCounter(&li);                                                                                  \
-        x = li.QuadPart;                                                                                               \
-    }
-#define RDTSC_E(x)                                                                                                     \
-    {                                                                                                                  \
-        LARGE_INTEGER li;                                                                                              \
-        QueryPerformanceCounter(&li);                                                                                  \
-        x = li.QuadPart - x;                                                                                           \
-    }
-
+#define RDTSC_B(x)    { x = SDL_GetPerformanceCounter(); }
+#define RDTSC_E(x)    { x = SDL_GetPerformanceCounter() - x; }
 //#define RDTSC_B(x)    { x = __rdtsc(); }
 //#define RDTSC_E(x)    { x = __rdtsc() - x; }
 

--- a/src/libs/core/src/compiler.cpp
+++ b/src/libs/core/src/compiler.cpp
@@ -621,7 +621,7 @@ VDATA *COMPILER::ProcessEvent(const char *event_name)
 
     bEventsBreak = false;
 
-    uint32_t nTimeOnEvent = GetTickCount();
+    uint32_t nTimeOnEvent = SDL_GetTicks();
     current_debug_mode = CDebug->GetTraceMode();
 
     pVD = nullptr;
@@ -689,7 +689,7 @@ VDATA *COMPILER::ProcessEvent(const char *event_name)
             break;
     }
 
-    nTimeOnEvent = GetTickCount() - nTimeOnEvent;
+    nTimeOnEvent = SDL_GetTicks() - nTimeOnEvent;
 
     nRuntimeTicks += nTimeOnEvent;
 

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -4145,7 +4145,7 @@ void DX9RENDER::StartProgressView()
         progressTipsTexture = TextureCreate(progressTipsImage);
         isInPViewProcess = false;
     }
-    progressUpdateTime = GetTickCount() - 1000;
+    progressUpdateTime = SDL_GetTicks() - 1000;
 }
 
 void DX9RENDER::ProgressView()
@@ -4156,7 +4156,7 @@ void DX9RENDER::ProgressView()
     if (isInPViewProcess)
         return;
     // Analyzing time
-    const uint32_t time = GetTickCount();
+    const uint32_t time = SDL_GetTicks();
     if (abs(static_cast<int32_t>(progressUpdateTime - time)) < 50)
         return;
     progressUpdateTime = time;

--- a/src/libs/sea_creatures/src/sharks.cpp
+++ b/src/libs/sea_creatures/src/sharks.cpp
@@ -511,7 +511,7 @@ Sharks::Sharks() : sea(0), island(0), indeces{}, vrt{}
 {
     rs = nullptr;
     camPos = 0.0f;
-    numShakes = 3 + (GetTickCount() & 3);
+    numShakes = 3 + (SDL_GetTicks() & 3);
     trackTx = -1;
     periscope.time = -1.0;
     waitPTime = -1.0f;
@@ -570,7 +570,7 @@ bool Sharks::Init()
                             const auto day = root->GetAttributeAsDword("day");
                             if (day == 7)
                             {
-                                if ((GetTickCount() & 7) == 5)
+                                if ((SDL_GetTicks() & 7) == 5)
                                 {
                                     waitPTime = 60.0f + rand() * 500.0f / RAND_MAX;
                                 }


### PR DESCRIPTION
In Windows:
`SDL_GetPerformanceCounter` just call `QueryPerformanceCounter`:
https://github.com/libsdl-org/SDL/blob/b1cf3229718a3e462608709254711c611dfab805/src/timer/windows/SDL_systimer.c#L128

`SDL_GetTicks` call `QueryPerformanceCounter` instead of `GetTickCount`, but results was very close in my tests:
https://github.com/libsdl-org/SDL/blob/b1cf3229718a3e462608709254711c611dfab805/src/timer/windows/SDL_systimer.c#L113