### PR TITLE
conan: fix missed mimalloc-redirect.dll

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -60,7 +60,7 @@ class StormEngine(ConanFile):
             if self.options.steam:
                 self.__install_lib("steam_api64.dll")
 
-            self.__install_lib("mimalloc-redirect.dll")
+            self.__install_bin("mimalloc-redirect.dll")
             if self.settings.build_type == "Debug":
                 self.__install_bin("mimalloc-debug.dll")
             else:


### PR DESCRIPTION
fix missed mimalloc-redirect.dll

![](https://media.discordapp.net/attachments/861645078760914955/991322310474743928/2022-06-28_15.40.54.png)

https://github.com/storm-devs/storm-engine/commit/ecd12523f9b8cbf33973d5614e9ffc6aa3014c62
<img width="578" alt="Снимок экрана 2022-07-01 в 22 08 31" src="https://user-images.githubusercontent.com/25062433/176955825-3eea084a-04b8-4d03-b6f1-6c7e7847be40.png">
