### PR TITLE
Fix crash when no lines need to be drawn in the battle navigator

### DIFF
--- a/src/libs/battle_interface/src/utils.cpp
+++ b/src/libs/battle_interface/src/utils.cpp
@@ -436,10 +436,7 @@ void BILinesInfo::Init(VDX9RENDER *rs, ATTRIBUTES *pA)
 
 void BILinesInfo::Draw()
 {
-    if (!lines.empty())
-    {
-        pRS->DrawLines2D(&lines[0], lines.size() / 2, "Line");
-    }
+    pRS->DrawLines2D(std::data(lines), lines.size() / 2, "Line");
 }
 
 BIImagesInfo::BIImagesInfo()

--- a/src/libs/battle_interface/src/utils.cpp
+++ b/src/libs/battle_interface/src/utils.cpp
@@ -436,7 +436,10 @@ void BILinesInfo::Init(VDX9RENDER *rs, ATTRIBUTES *pA)
 
 void BILinesInfo::Draw()
 {
-    pRS->DrawLines2D(&lines[0], lines.size() / 2, "Line");
+    if (!lines.empty())
+    {
+        pRS->DrawLines2D(&lines[0], lines.size() / 2, "Line");
+    }
 }
 
 BIImagesInfo::BIImagesInfo()


### PR DESCRIPTION
Just a quick fix for a crash I encountered while debugging New Horizons