### PR TITLE
Fix building on Linux CI

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -31,7 +31,8 @@ class StormEngine(ConanFile):
             # conan-center
             self.requires("libsafec/3.6.0")
             self.requires("openssl/1.1.1o")#TODO: update sentry-native@storm/patched and then remove it
-            self.options["sdl"].pulse = False
+            # don't change options["sdl"] if you want to use prebuilt package from https://conan.io/center/sdl?version=2.0.18&tab=configuration&os=Linux
+            #self.options["sdl"].pulse = False
         if self.options.steam:
             self.requires("steamworks/1.5.1@storm/prebuilt")
 

--- a/src/apps/engine/CMakeLists.txt
+++ b/src/apps/engine/CMakeLists.txt
@@ -12,6 +12,8 @@ set(SYSTEM_DEPS
     "dbghelp"
     "winhttp"
 )
+else()
+set(SYSTEM_DEPS "ffi")
 endif()
 
 STORM_SETUP(


### PR DESCRIPTION
Linux CI was broken. Problem starts when ConanCenter changed some configs needed for building SDL2.
Best and simplest solution for now - use prebuilt version of SDL2 from ConanCenter:
https://conan.io/center/sdl?version=2.0.18&tab=configuration&os=Linux