### PR TITLE
add clang-12 build to Linux CI

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -34,7 +34,8 @@ jobs:
       fail-fast: false
       matrix:
         configuration: [Debug]
-    name: 'build-linux [${{ matrix.configuration}}]'
+        clang_version: [11, 12]
+    name: 'linux [${{ matrix.configuration}}] [clang-${{matrix.clang_version}}]'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -48,8 +49,8 @@ jobs:
       run: pip install conan
     - name: Configure with cmake
       run: |
-        export CC=clang-11
-        export CXX=clang++-11
+        export CC=clang-${{matrix.clang_version}}
+        export CXX=clang++-${{matrix.clang_version}}
         ${CXX} --version
         mkdir build && cd build
         cmake .. -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.configuration}}

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -38,7 +38,7 @@ jobs:
         include:
           - enable_steam: true
             configuration: msvc-release
-    name: 'build-windows [${{ matrix.configuration}}, steam: ${{ matrix.enable_steam }}]'
+    name: 'windows [${{ matrix.configuration}}, steam: ${{ matrix.enable_steam }}]'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/conanfile.py
+++ b/conanfile.py
@@ -30,9 +30,9 @@ class StormEngine(ConanFile):
         else:
             # conan-center
             self.requires("libsafec/3.6.0")
-            self.requires("openssl/1.1.1o")#TODO: update sentry-native@storm/patched and then remove it
-            # don't change options["sdl"] if you want to use prebuilt package from https://conan.io/center/sdl?version=2.0.18&tab=configuration&os=Linux
-            #self.options["sdl"].pulse = False
+            self.requires("wayland/1.20.0#ae7daf789db25b25ad2e22969fd9ae9d")#fix for error: Could not find WAYLAND_SCANNER using the following names: wayland-scanner
+            self.requires("libiconv/1.17")#fix for error: 'gettext/0.21' requires 'libiconv/1.17' while 'pulseaudio/14.2' requires 'libiconv/1.16'
+            self.requires("openssl/1.1.1n")#fix for error: 'sentry-crashpad/0.4.13' requires 'openssl/1.1.1n' while 'pulseaudio/14.2' requires 'openssl/1.1.1q'
         if self.options.steam:
             self.requires("steamworks/1.5.1@storm/prebuilt")
 


### PR DESCRIPTION
It's usefull to have 2 build versions: clang-11 - for prebuild conan packages and clang-12 for building packages from source code.