### PR TITLE
Make flag textures dynamically configurable

### DIFF
--- a/src/libs/rigging/src/flag.cpp
+++ b/src/libs/rigging/src/flag.cpp
@@ -13,7 +13,6 @@ FLAG::FLAG()
 {
     bUse = false;
     RenderService = nullptr;
-    TextureName = nullptr;
     bFirstRun = true;
     texl = -1;
     flist = nullptr;
@@ -29,7 +28,6 @@ FLAG::FLAG()
 FLAG::~FLAG()
 {
     TEXTURE_RELEASE(RenderService, texl);
-    STORM_DELETE(TextureName);
     STORM_DELETE(gdata);
     VERTEX_BUFFER_RELEASE(RenderService, vBuf);
     INDEX_BUFFER_RELEASE(RenderService, iBuf);
@@ -63,7 +61,7 @@ void FLAG::SetDevice()
     globalWind.ang.z = 1.f;
     globalWind.base = 1.f;
     LoadIni();
-    texl = RenderService->TextureCreate(TextureName);
+    texl = RenderService->TextureCreate(textureName_.c_str());
 }
 
 bool FLAG::CreateState(ENTITY_STATE_GEN *state_gen)
@@ -79,7 +77,14 @@ bool FLAG::LoadState(ENTITY_STATE *state)
 void FLAG::Execute(uint32_t Delta_Time)
 {
     if (bFirstRun)
+    {
         FirstRun();
+    }
+    else
+    {
+        SetTextureCoordinate();
+    }
+
     if (bYesDeleted)
         DoSTORM_DELETE();
     if (bUse)
@@ -198,14 +203,25 @@ uint64_t FLAG::ProcessMessage(MESSAGE &message)
             for (i = 0; i < gi.nlabels; i++)
             {
                 nod->geo->GetLabel(i, gl);
-                if (!strncmp(gl.group_name, "sflag", 5)) // special flag
+
+                const std::string_view &group_name = gl.group_name;
+
+                if (group_name.starts_with("sflag")) // special flag
                 {
-                    AddLabel(gl, nod, 1, 1);
+                    int groupNumber = atoi(group_name.substr(5).data());
+                    AddLabel(gl, nod, true, true, groupNumber);
                 }
-                else
+                else if (group_name.starts_with("penn"))
                 {
-                    if (!strncmp(gl.group_name, "flag", 4)) // ordinary flag
-                        AddLabel(gl, nod, 0, 1);
+                    // pennant
+                    int groupNumber = atoi(group_name.substr(4).data());
+                    AddLabel(gl, nod, true, true, groupNumber);
+                }
+                else if (group_name.starts_with("flag"))
+                {
+                    // ordinary flag
+                    int groupNumber = atoi(group_name.substr(4).data());
+                    AddLabel(gl, nod, false, true, groupNumber);
                 }
             }
         }
@@ -260,14 +276,19 @@ uint64_t FLAG::ProcessMessage(MESSAGE &message)
             for (i = 0; i < gi.nlabels; i++)
             {
                 nod->geo->GetLabel(i, gl);
-                if (!strncmp(gl.group_name, "sflag", 5)) // special flag
+
+                const std::string_view &group_name = gl.group_name;
+
+                if (group_name.starts_with("sflag")) // special flag
                 {
-                    AddLabel(gl, nod, 1, 0);
+                    int groupNumber = atoi(group_name.substr(5).data());
+                    AddLabel(gl, nod, true, false, groupNumber);
                 }
-                else
+                else if (group_name.starts_with("flag"))
                 {
-                    if (!strncmp(gl.group_name, "flag", 4)) // ordinary flag
-                        AddLabel(gl, nod, 0, 0);
+                    // ordinary flag
+                    int groupNumber = atoi(group_name.substr(4).data());
+                    AddLabel(gl, nod, false, false, groupNumber);
                 }
             }
         }
@@ -291,9 +312,9 @@ uint64_t FLAG::ProcessMessage(MESSAGE &message)
     return 0;
 }
 
-void FLAG::SetTextureCoordinate() const
+void FLAG::SetTextureCoordinate()
 {
-    if (bUse)
+    if (bUse && verticesNeedUpdate_)
     {
         int i;
         int32_t sIdx;
@@ -339,6 +360,7 @@ void FLAG::SetTextureCoordinate() const
                 }
             }
             RenderService->UnLockVertexBuffer(vBuf);
+            verticesNeedUpdate_ = false;
         }
     }
 }
@@ -443,24 +465,18 @@ void FLAG::DoMove(FLAGDATA *pr, float delta_time) const
     }
 }
 
-void FLAG::AddLabel(GEOS::LABEL &gl, NODE *nod, bool isSpecialFlag, bool isShip)
+void FLAG::AddLabel(GEOS::LABEL &gl, NODE *nod, bool isSpecialFlag, bool isShip, int groupNumber)
 {
     FLAGDATA *fd;
-    int grNum;
 
     // for fail parameters do not set of data
     if (nod == nullptr)
         return;
 
-    if (isSpecialFlag)
-        grNum = atoi(&gl.group_name[5]);
-    else
-        grNum = atoi(&gl.group_name[4]);
-
     int fn;
     for (fn = 0; fn < flagQuantity; fn++)
-        if (flist[fn] != nullptr && flist[fn]->HostGroup == groupQuantity - 1 && flist[fn]->grNum == grNum &&
-            flist[fn]->nod == nod)
+        if (flist[fn] != nullptr && flist[fn]->HostGroup == groupQuantity - 1 && flist[fn]->grNum == groupNumber &&
+            flist[fn]->nod == nod && flist[fn]->isSpecialFlag == isSpecialFlag)
         {
             fd = flist[fn];
             break;
@@ -477,7 +493,7 @@ void FLAG::AddLabel(GEOS::LABEL &gl, NODE *nod, bool isSpecialFlag, bool isShip)
         fd->isShip = isShip;
         fd->pMatWorld = &nod->glob_mtx;
         fd->nod = nod;
-        fd->grNum = grNum;
+        fd->grNum = groupNumber;
         fd->Alfa = 0.f;
         fd->Beta = 0.f;
         fd->HostGroup = groupQuantity - 1;
@@ -581,24 +597,7 @@ void FLAG::LoadIni()
     int tmp;
     // load texture parameters
     ini->ReadString(section, "TextureName", param, sizeof(param) - 1, "flagall.tga");
-    if (TextureName != nullptr)
-    {
-        if (strcmp(TextureName, param))
-        {
-            delete TextureName;
-            const auto len = strlen(param) + 1;
-            TextureName = new char[len];
-            memcpy(TextureName, param, len);
-            RenderService->TextureRelease(texl);
-            texl = RenderService->TextureCreate(TextureName);
-        }
-    }
-    else
-    {
-        const auto len = strlen(param) + 1;
-        TextureName = new char[len];
-        memcpy(TextureName, param, len);
-    }
+    UpdateTexture(param);
 
     if (core.GetTargetEngineVersion() <= storm::ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS)
     {
@@ -611,6 +610,7 @@ void FLAG::LoadIni()
         FlagTextureQuantityRow = static_cast<int>(ini->GetInt(section, "TextureCountRow", 8));
     }
 
+    verticesNeedUpdate_ = true;
     SetTextureCoordinate();
 
     // flag segment length
@@ -645,6 +645,28 @@ void FLAG::LoadIni()
     // UNGUARD
 }
 
+uint32_t FLAG::AttributeChanged(ATTRIBUTES *attributes)
+{
+    const std::string_view attributeName = attributes->GetThisName();
+
+    if (storm::iEquals(attributeName, "texture"))
+    {
+        UpdateTexture(attributes->GetValue());
+    }
+    else if (storm::iEquals(attributeName, "textureColumns"))
+    {
+        FlagTextureQuantity = atoll(attributes->GetValue().c_str());
+        verticesNeedUpdate_ = true;
+    }
+    else if (storm::iEquals(attributeName, "textureRows"))
+    {
+        FlagTextureQuantityRow = atoll(attributes->GetValue().c_str());
+        verticesNeedUpdate_ = true;
+    }
+
+    return Entity::AttributeChanged(attributes);
+}
+
 void FLAG::FirstRun()
 {
     if (wFlagLast)
@@ -662,6 +684,7 @@ void FLAG::FirstRun()
         iBuf = RenderService->CreateIndexBuffer(nIndx * 2);
         SetTreangle();
         vBuf = RenderService->CreateVertexBuffer(FLAGLXVERTEX_FORMAT, nVert * sizeof(FLAGLXVERTEX), D3DUSAGE_WRITEONLY);
+        verticesNeedUpdate_ = true;
         SetTextureCoordinate();
         nIndx /= 3;
     }
@@ -775,6 +798,7 @@ void FLAG::DoSTORM_DELETE()
             gdata = oldgdata;
 
         SetTreangle();
+        verticesNeedUpdate_ = true;
         SetTextureCoordinate();
     }
 
@@ -839,8 +863,8 @@ void FLAG::SetAdd(int flagNum)
             // set texture number
             if (core.GetTargetEngineVersion() <= storm::ENGINE_VERSION::CITY_OF_ABANDONED_SHIPS)
             {
-                pvdat = core.Event("GetRiggingData", "sll", "GetFlagTexNum", flist[fn]->triangle,
-                                   gdata[flist[fn]->HostGroup].nation);
+                pvdat = core.Event("GetRiggingData", "slll", "GetFlagTexNum", flist[fn]->triangle,
+                                   gdata[flist[fn]->HostGroup].nation, flist[fn]->isSpecialFlag);
             }
             else
             {
@@ -949,4 +973,14 @@ void FLAG::MoveOtherHost(entid_t newm_id, int32_t flagNum, entid_t oldm_id)
     // reassign its owner to the new owner
     if (fn < flagQuantity)
         flist[fn]->HostGroup = newgn;
+}
+
+void FLAG::UpdateTexture(const std::string_view &texturePath)
+{
+    if (textureName_ != texturePath)
+    {
+        textureName_ = texturePath;
+        RenderService->TextureRelease(texl);
+        texl = RenderService->TextureCreate(textureName_.c_str());
+    }
 }

--- a/src/libs/rigging/src/flag.h
+++ b/src/libs/rigging/src/flag.h
@@ -45,8 +45,9 @@ class FLAG : public Entity
 
     bool bUse;
     bool bFirstRun;
+    bool verticesNeedUpdate_ = true;
     VDX9RENDER *RenderService;
-    char *TextureName;
+    std::string textureName_;
     int32_t texl;
 
     struct WIND
@@ -88,6 +89,8 @@ class FLAG : public Entity
               RestoreRender(delta); break;*/
         }
     }
+
+    uint32_t AttributeChanged(ATTRIBUTES *attributes) override;
 
   private:
     struct FLAGDATA
@@ -144,16 +147,17 @@ class FLAG : public Entity
     GROUPDATA *gdata;
 
     void FirstRun();
-    void SetTextureCoordinate() const;
+    void SetTextureCoordinate();
     void SetTreangle() const;
     void DoMove(FLAGDATA *pr, float delta_time) const;
-    void AddLabel(GEOS::LABEL &gl, NODE *nod, bool isSpecialFlag, bool isShip);
+    void AddLabel(GEOS::LABEL &gl, NODE *nod, bool isSpecialFlag, bool isShip, int groupNumber);
     void SetAll();
     void LoadIni();
     void GroupSTORM_DELETE(entid_t m_id);
     void DoSTORM_DELETE();
     void SetAdd(int flagNum);
     void MoveOtherHost(entid_t newm_id, int32_t flagNum, entid_t oldm_id);
+    void UpdateTexture(const std::string_view &texturePath);
 
     FLAGLXVERTEX *vertBuf;
     uint16_t *indxBuf;

--- a/src/libs/rigging/src/flag.h
+++ b/src/libs/rigging/src/flag.h
@@ -128,6 +128,7 @@ class FLAG : public Entity
 
         int HostGroup;
         bool bDeleted;
+        bool bDisabled = false;
     };
 
     int flagQuantity;

--- a/src/libs/shared_headers/include/shared/messages.h
+++ b/src/libs/shared_headers/include/shared/messages.h
@@ -70,6 +70,7 @@
 #define MSG_SHIP_RESET_TRACK 50309
 #define MSG_SHIP_SETLIGHTSOFF 50310
 #define MSG_SHIP_FLAG_REFRESH 50312 // boal 20.08.06
+#define MSG_SHIP_SET_CUSTOM_FLAG 50313 // "li", flag entity - Specify a custom flag entity to use for this ship
 #define MSG_SHIP_SAFE_DELETE 50315
 #define MSG_SHIP_GET_SAIL_STATE 50325
 #define MSG_SHIP_CURVES 50400

--- a/src/libs/ship/src/ship.cpp
+++ b/src/libs/ship/src/ship.cpp
@@ -1290,10 +1290,23 @@ uint64_t SHIP::ProcessMessage(MESSAGE &message)
         // boal 20.08.06 redrawing the flag -->
     case MSG_SHIP_FLAG_REFRESH:
         core.Send_Message(flag_id, "li", MSG_FLAG_DEL_GROUP, GetModelEID());
-        if (flag_id = core.GetEntityId("flag"))
+        if (flagEntity_ != invalid_entity) {
+            flag_id = flagEntity_;
+        }
+        else {
+            flag_id = core.GetEntityId("flag");
+        }
+        if (flag_id)
             core.Send_Message(flag_id, "lili", MSG_FLAG_INIT, GetModelEID(), GetNation(GetACharacter()), GetId());
         break;
         // boal 20.08.06 redrawing the flag <--
+    case MSG_SHIP_SET_CUSTOM_FLAG: {
+        const entid_t flag_entity = message.EntityID();
+        if (flag_entity != invalid_entity) {
+            flagEntity_ = flag_entity;
+        }
+        break;
+    }
     case MSG_SHIP_LIGHTSRESET: {
         const auto bLight = message.Long() != 0;
         if (const auto pShipsLights = static_cast<IShipLights *>(core.GetEntityPointer(shipLights)))
@@ -1444,7 +1457,13 @@ bool SHIP::Mount(ATTRIBUTES *_pAShip)
         core.Send_Message(rope_id, "lii", MSG_ROPE_INIT, GetId(), GetModelEID());
 
     // flags
-    if (flag_id = core.GetEntityId("flag"))
+    if (flagEntity_ != invalid_entity) {
+        flag_id = flagEntity_;
+    }
+    else {
+        flag_id = core.GetEntityId("flag");
+    }
+    if (flag_id)
         core.Send_Message(flag_id, "lili", MSG_FLAG_INIT, GetModelEID(), GetNation(GetACharacter()), GetId());
 
     // vants

--- a/src/libs/ship/src/ship.h
+++ b/src/libs/ship/src/ship.h
@@ -94,6 +94,7 @@ class SHIP : public SHIP_BASE
 
     // Ships lights
     entid_t shipLights;
+    entid_t flagEntity_{};
 
     // Fire places
     std::vector<FirePlace> aFirePlaces;


### PR DESCRIPTION
Makes flag textures configurable at runtime by setting the `texture`, `textureColumns` and `textureRows` attributes.
Adds a MSG_SHIP_SET_CUSTOM_FLAG message that enables you to use a specific flag entity per ship.

Combined these enable the use of a large amount of different flags spread across different textures.