### PR TITLE
Fix crash when creating AIGroup during SituationCheck

### DIFF
--- a/src/libs/sea_ai/src/sea_ai.cpp
+++ b/src/libs/sea_ai/src/sea_ai.cpp
@@ -45,9 +45,12 @@ void SEA_AI::Execute(uint32_t Delta_Time)
         bFirstInit = false;
     }
 
-    for (auto &i : AIGroup::AIGroups)
+    // Don't use range-based for loop here. AIGroup::AIGroups can be pushed to while executing, potentially invalidating
+    // any iterators
+    for (size_t i = 0; i < AIGroup::AIGroups.size(); ++i)
     {
-        i->Execute(fDeltaTime);
+        const auto group = AIGroup::AIGroups[i];
+        group->Execute(fDeltaTime);
     }
 
     RDTSC_E(dwRDTSC);


### PR DESCRIPTION
New Horizons has a feature where ships can surrender during battle. This check happens during the `SHIP_CHECK_SITUATION` event. This creates a new "surrendered" group, potentially resizing the static `AIGroup::AIGroups` vector, which then invalidates the iterators in `SEA_AI::Execute` it is called from, crashing the game.

This is a workaround by simply using the index instead of an iterator in the loop.