### PR TITLE
Add options for display selection and window borders to engine.ini

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -177,7 +177,9 @@ int main(int argc, char *argv[])
     uint32_t dwMaxFPS = 0;
     bool bSteam = false;
     int width = 1024, height = 768;
+    int preferred_display = 0;
     bool fullscreen = false;
+    bool show_borders = false;
 
     if (ini)
     {
@@ -190,7 +192,9 @@ int main(int argc, char *argv[])
         }
         width = ini->GetInt(nullptr, "screen_x", 1024);
         height = ini->GetInt(nullptr, "screen_y", 768);
-        fullscreen = ini->GetInt(nullptr, "full_screen", false) ? true : false;
+        preferred_display = ini->GetInt(nullptr, "display", 0);
+        fullscreen = ini->GetInt(nullptr, "full_screen", false);
+        show_borders = ini->GetInt(nullptr, "window_borders", false);
         bSteam = ini->GetInt(nullptr, "Steam", 1) != 0;
     }
 
@@ -205,7 +209,8 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    std::shared_ptr<storm::OSWindow> window = storm::OSWindow::Create(width, height, fullscreen);
+    std::shared_ptr<storm::OSWindow> window =
+        storm::OSWindow::Create(width, height, preferred_display, fullscreen, show_borders);
     window->SetTitle("Sea Dogs");
     core_private->Set_Hwnd(static_cast<HWND>(window->OSHandle()));
     window->Subscribe(HandleWindowEvent);

--- a/src/libs/window/include/os_window.hpp
+++ b/src/libs/window/include/os_window.hpp
@@ -62,6 +62,7 @@ class OSWindow
     virtual void *OSHandle() = 0;
 
     //! Create new window
-    static std::shared_ptr<OSWindow> Create(int width, int height, bool fullscreen);
+    static std::shared_ptr<OSWindow> Create(int width, int height, int preferred_display, bool fullscreen,
+                                            bool bordered);
 };
 } // namespace storm

--- a/src/libs/window/src/sdl_window.cpp
+++ b/src/libs/window/src/sdl_window.cpp
@@ -1,22 +1,23 @@
 #include "sdl_window.hpp"
 
 #include <SDL2/SDL_syswm.h>
-#include <map>
 
 namespace storm
 {
-SDLWindow::SDLWindow(int width, int height, bool fullscreen) : fullscreen_(fullscreen)
+SDLWindow::SDLWindow(int width, int height, int preferred_display, bool fullscreen, bool bordered)
+    : fullscreen_(fullscreen)
 {
     uint32_t flags = (fullscreen ? SDL_WINDOW_FULLSCREEN : 0) | SDL_WINDOW_HIDDEN;
 #ifndef _WIN32 // DXVK-Native
     flags |= SDL_WINDOW_VULKAN;
 #endif
     window_ = std::unique_ptr<SDL_Window, std::function<void(SDL_Window *)>>(
-        SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, flags),
+        SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED_DISPLAY(preferred_display),
+                         SDL_WINDOWPOS_CENTERED_DISPLAY(preferred_display), width, height, flags),
         [](SDL_Window *w) { SDL_DestroyWindow(w); });
 
     sdlID_ = SDL_GetWindowID(window_.get());
-    SDL_SetWindowBordered(window_.get(), SDL_FALSE);
+    SDL_SetWindowBordered(window_.get(), bordered ? SDL_TRUE : SDL_FALSE);
     SDL_AddEventWatch(&SDLEventHandler, this);
 }
 
@@ -143,9 +144,9 @@ void SDLWindow::ProcessEvent(const SDL_WindowEvent &evt)
         handler.second(winEvent);
 }
 
-std::shared_ptr<OSWindow> OSWindow::Create(int width, int height, bool fullscreen)
+std::shared_ptr<OSWindow> OSWindow::Create(int width, int height, int preferred_display, bool fullscreen, bool bordered)
 {
-    return std::make_shared<SDLWindow>(width, height, fullscreen);
+    return std::make_shared<SDLWindow>(width, height, preferred_display, fullscreen, bordered);
 }
 
 int SDLWindow::SDLEventHandler(void *userdata, SDL_Event *evt)

--- a/src/libs/window/src/sdl_window.hpp
+++ b/src/libs/window/src/sdl_window.hpp
@@ -9,7 +9,7 @@ namespace storm
 class SDLWindow : public OSWindow
 {
   public:
-    SDLWindow(int width, int height, bool fullscreen);
+    SDLWindow(int width, int height, int preferred_display, bool fullscreen, bool bordered);
     ~SDLWindow() override;
 
     void Show() override;


### PR DESCRIPTION
Exposes two new options to the engine.ini file:

`display`: the index of the display/monitor the game should be shown on, default = `0`
`window_borders`: show window borders when running in windowed mode, allowing you to move the window, default = `0` / disabled