### PR TITLE
Fix crash when playing bow splash sound effect

### DIFF
--- a/src/libs/sea_foam/src/seafoam.cpp
+++ b/src/libs/sea_foam/src/seafoam.cpp
@@ -425,14 +425,15 @@ void SEAFOAM::RealizeShipFoam_Particles(tShipFoamInfo &_shipFoamInfo, uint32_t _
 
     if (soundService && (_shipFoamInfo.doSplash))
     {
+        auto pos = _shipFoamInfo.shipModel->mtx * CVECTOR(0.f, 0.f, _shipFoamInfo.hullInfo.boxsize.z / 2.f);
+        pos.y = sea->WaveXZ(pos.x, pos.z);
+
         if (!_shipFoamInfo.sound || !soundService->SoundIsPlaying(_shipFoamInfo.sound))
-            _shipFoamInfo.sound = soundService->SoundPlay("ship_bow", PCM_3D, VOLUME_FX, false, false, true);
-        //_shipFoamInfo.sound = soundService->SoundPlay("ship_bow", PCM_3D, VOLUME_FX, false, true, true);
-        if (_shipFoamInfo.sound)
         {
-            auto pos = _shipFoamInfo.shipModel->mtx * CVECTOR(0.f, 0.f, _shipFoamInfo.hullInfo.boxsize.z / 2.f);
-            pos.y = sea->WaveXZ(pos.x, pos.z);
-            // soundService->SoundSetVolume(_shipFoamInfo.sound, _shipFoamInfo.splashFactor);
+            _shipFoamInfo.sound = soundService->SoundPlay("ship_bow", PCM_3D, VOLUME_FX, false, false, true, 0, &pos);
+        }
+        else if (_shipFoamInfo.sound)
+        {
             soundService->SoundSet3DParam(_shipFoamInfo.sound, SM_POSITION, &pos);
         }
     }

--- a/src/libs/sound_service/src/sound_service.cpp
+++ b/src/libs/sound_service/src/sound_service.cpp
@@ -452,10 +452,12 @@ TSD_ID SoundService::SoundPlay(const char *_name, eSoundType _type, eVolumeType 
                                                                           _maxDistance * DISTANCEFACTOR));
 
         FMOD_VECTOR vVelocity = {0.0f, 0.0f, 0.0f};
-        FMOD_VECTOR vPosition;
-        vPosition.x = _startPosition->x;
-        vPosition.y = _startPosition->y;
-        vPosition.z = _startPosition->z;
+        FMOD_VECTOR vPosition{};
+        if (_startPosition != nullptr) {
+            vPosition.x = _startPosition->x;
+            vPosition.y = _startPosition->y;
+            vPosition.z = _startPosition->z;
+        }
         CHECKFMODERR(PlayingSounds[SoundIdx].channel->set3DAttributes(&vPosition, &vVelocity));
     }
 


### PR DESCRIPTION
The bow splash sound effect that is supposed to play during storms, was begin played as a `PCM_3D` sound, but without passing a position. This fixes that by passing the position directly during play start.

I've also added a check to just use a zero position instead of crashing should this ever happens again.