### PR TITLE
Fix rendering glitch caused by XI_Glower

### DIFF
--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -3394,8 +3394,9 @@ void DX9RENDER::DrawRects(RS_RECT *pRSR, uint32_t dwRectsNum, const char *cBlock
 
     bool bDraw = true;
 
-    static CMatrix camMtx, IMatrix;
+    static CMatrix camMtx, oldWorldMatrix, IMatrix;
     d3d9->GetTransform(D3DTS_VIEW, camMtx);
+    d3d9->GetTransform(D3DTS_WORLD, oldWorldMatrix);
 
     fScaleY *= GetHeightDeformator();
 
@@ -3502,6 +3503,7 @@ void DX9RENDER::DrawRects(RS_RECT *pRSR, uint32_t dwRectsNum, const char *cBlock
     }
 
     d3d9->SetTransform(D3DTS_VIEW, camMtx);
+    d3d9->SetTransform(D3DTS_WORLD, oldWorldMatrix);
 }
 
 void DX9RENDER::DrawSprites(RS_SPRITE *pRSS, uint32_t dwSpritesNum, const char *cBlockName)


### PR DESCRIPTION
`DX9RENDER::DrawRects` resets the world matrix without restoring it afterwards.

This caused an issue in combination with the `CXI_GLOWER` interface element, causing the world matrix to be reset during mouse cursor drawing.

I'm pretty sure none of the newer games used the _Glows_ element, so that is probably why this went undetected.