### PR TITLE
Fix crash when creating a message with an uninitialized reference parameter

### DIFF
--- a/src/libs/core/src/internal_functions.cpp
+++ b/src/libs/core/src/internal_functions.cpp
@@ -2678,7 +2678,7 @@ bool COMPILER::CreateMessage(MESSAGE *pMs, uint32_t s_off, uint32_t var_offset, 
             break;
         case 'i':
             pV = pV->GetVarPointer();
-            if (!(pV->GetType() == VAR_OBJECT || pV->GetType() == VAR_AREFERENCE))
+            if (pV == nullptr || !(pV->GetType() == VAR_OBJECT || pV->GetType() == VAR_AREFERENCE))
             {
                 SetError("CreateMessage: Invalid Data");
                 return false;


### PR DESCRIPTION
A simple fix to prevent the game from crashing when you create a message with an uninitialized reference.

Like:
```
ref flag; // Uninitialized
SendMessage(rCharacter, "li", MSG_SHIP_SET_CUSTOM_FLAG, &flag);
```