### PR TITLE
diagnostics: sentry-native update

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,9 +16,9 @@ class StormEngine(ConanFile):
 
     # dependencies used in deploy binaries
     # conan-center
-    requires = ["zlib/1.2.11", "spdlog/1.9.2", "fast_float/3.4.0", "sdl/2.0.18", "mimalloc/2.0.3",
+    requires = ["zlib/1.2.11", "spdlog/1.9.2", "fast_float/3.4.0", "sdl/2.0.18", "mimalloc/2.0.3", "sentry-native/0.5.0",
     # storm.jfrog.io
-    "sentry-native/0.4.13@storm/patched", "directx/9.0@storm/prebuilt", "fmod/2.02.05@storm/prebuilt"]
+    "directx/9.0@storm/prebuilt", "fmod/2.02.05@storm/prebuilt"]
     # aux dependencies (e.g. for tests)
     build_requires = "catch2/2.13.7"
 

--- a/src/libs/diagnostics/include/lifecycle_diagnostics_service.hpp
+++ b/src/libs/diagnostics/include/lifecycle_diagnostics_service.hpp
@@ -57,7 +57,7 @@ class LifecycleDiagnosticsService final
     std::unique_ptr<LoggingService> loggingService_;
     crash_info_collector collectCrashInfo_;
 
-    static sentry_value_t beforeCrash(sentry_value_t event, void *hint, void *closure);
+    static sentry_value_t beforeCrash(const sentry_ucontext_t *uctx, sentry_value_t event, void *closure);
 };
 
 } // namespace storm::diag


### PR DESCRIPTION
- update sentry-native to 0.5.0; switch to upstream baseline
- new approach for retrieving EXCEPTION_POINTERS
- enable sentry-native logging in debug