### PR TITLE
Gamma/brightness/contrast in windowed mode

### DIFF
--- a/src/apps/engine/CMakeLists.txt
+++ b/src/apps/engine/CMakeLists.txt
@@ -1,10 +1,10 @@
 # this is something I really don't like but it seems there's not better way to ensure mimalloc is linked before c-runtime
-include(${CMAKE_BINARY_DIR}/conanbuildinfo_multi.cmake)
-if (WIN32)
-  set(MIMALLOC_DEP "$<IF:$<CONFIG:Release>,${CONAN_LIB_DIRS_MIMALLOC_RELEASE}/mimalloc.lib,${CONAN_LIB_DIRS_MIMALLOC_DEBUG}/mimalloc-debug.lib>")
-else()
-  set(MIMALLOC_DEP "$<IF:$<CONFIG:Release>,${CONAN_LIB_DIRS_MIMALLOC_RELEASE}/libmimalloc.so,${CONAN_LIB_DIRS_MIMALLOC_DEBUG}/libmimalloc-debug.so>")
-endif()
+#include(${CMAKE_BINARY_DIR}/conanbuildinfo_multi.cmake)
+#if (WIN32)
+#  set(MIMALLOC_DEP "$<IF:$<CONFIG:Release>,${CONAN_LIB_DIRS_MIMALLOC_RELEASE}/mimalloc.lib,${CONAN_LIB_DIRS_MIMALLOC_DEBUG}/mimalloc-debug.lib>")
+#else()
+#  set(MIMALLOC_DEP "$<IF:$<CONFIG:Release>,${CONAN_LIB_DIRS_MIMALLOC_RELEASE}/libmimalloc.so,${CONAN_LIB_DIRS_MIMALLOC_DEBUG}/libmimalloc-debug.so>")
+#endif()
 
 if (WIN32)
 set(SYSTEM_DEPS

--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -10,8 +10,8 @@
 #include "logging.hpp"
 #include "os_window.hpp"
 #include "steam_api.hpp"
-#include "v_sound_service.h"
 #include "storm/fs.h"
+#include "v_sound_service.h"
 #include "watermark.hpp"
 
 namespace
@@ -53,7 +53,6 @@ void RunFrameWithOverflowCheck()
 #else
 #define RunFrameWithOverflowCheck RunFrame
 #endif
-
 
 void mimalloc_fun(const char *msg, void *arg)
 {
@@ -212,9 +211,9 @@ int main(int argc, char *argv[])
     std::shared_ptr<storm::OSWindow> window =
         storm::OSWindow::Create(width, height, preferred_display, fullscreen, show_borders);
     window->SetTitle("Sea Dogs");
-    core_private->Set_Hwnd(static_cast<HWND>(window->OSHandle()));
     window->Subscribe(HandleWindowEvent);
     window->Show();
+    core_private->SetWindow(window);
 
     // Init core
     core_private->InitBase();

--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME core
     TYPE library
-    DEPENDENCIES diagnostics shared_headers steam_api fast_float sdl
+    DEPENDENCIES diagnostics shared_headers steam_api fast_float sdl window
 )

--- a/src/libs/core/include/core.h
+++ b/src/libs/core/include/core.h
@@ -9,6 +9,7 @@
 #include "v_data.h"
 #include "v_file_service.h"
 #include "shared/layers.h"
+#include "os_window.hpp"
 
 struct IFUNCINFO;
 
@@ -23,8 +24,8 @@ class Core
   public:
     virtual ~Core() = default;
 
-    // return application handle
-    virtual void* GetAppHWND() = 0;
+    // return application window
+    virtual storm::OSWindow *GetWindow() = 0;
     // set time scale; affect on std entity functions DeltaTime parameter
     virtual void SetTimeScale(float _scale) = 0;
     // write message to system log file

--- a/src/libs/core/include/core_private.h
+++ b/src/libs/core/include/core_private.h
@@ -20,5 +20,5 @@ public:
 
     virtual void collectCrashInfo() const = 0;
 
-    virtual void Set_Hwnd(HWND _hwnd) = 0;
+    virtual void SetWindow(std::shared_ptr<storm::OSWindow> window) = 0;
 };

--- a/src/libs/core/src/core_impl.cpp
+++ b/src/libs/core/src/core_impl.cpp
@@ -81,11 +81,15 @@ void CoreImpl::CleanUp()
     delete[] State_file_name;
 }
 
+void CoreImpl::SetWindow(std::shared_ptr<storm::OSWindow> window)
+{
+    window_ = std::move(window);
+}
+
 void CoreImpl::Init()
 {
     Initialized = false;
     bEngineIniProcessed = false;
-    App_Hwnd = nullptr;
     State_file_name = nullptr;
     Exit_flag = false;
     State_loading = false;
@@ -321,12 +325,9 @@ void CoreImpl::Exit()
     Exit_flag = true;
 }
 
-//------------------------------------------------------------------------------------------------
-// return application window handle
-//
-void* CoreImpl::GetAppHWND()
+storm::OSWindow * CoreImpl::GetWindow()
 {
-    return App_Hwnd;
+    return window_.get();
 }
 
 #ifdef _WIN32 // HINSTANCE

--- a/src/libs/core/src/core_impl.h
+++ b/src/libs/core/src/core_impl.h
@@ -22,10 +22,7 @@ class CoreImpl final : public CorePrivate
 
     void CleanUp();
 
-    void Set_Hwnd(HWND _hwnd)
-    {
-        App_Hwnd = _hwnd;
-    };
+    void SetWindow(std::shared_ptr<storm::OSWindow> window) override;
     bool Initialize();
     void ResetCore();
     bool Run();
@@ -60,7 +57,7 @@ class CoreImpl final : public CorePrivate
     // shutdown core, delete all objects and close programm
     void Exit();
     // return application handle
-    void* GetAppHWND() override;
+    storm::OSWindow *GetWindow() override;
 #ifdef _WIN32 // HINSTANCE
     HINSTANCE GetAppInstance();
 #endif
@@ -163,7 +160,7 @@ private:
     bool Root_flag;
     bool Initialized; // initialized flag (false at startup or after Reset())
     bool bEngineIniProcessed;
-    HWND App_Hwnd;             // application handle
+    std::shared_ptr<storm::OSWindow> window_; // application handle
     char gstring[MAX_PATH]{}; // general purpose string
     bool State_loading;
     bool bEnableTimeScale{};

--- a/src/libs/diagnostics/src/lifecycle_diagnostics_service.cpp
+++ b/src/libs/diagnostics/src/lifecycle_diagnostics_service.cpp
@@ -52,7 +52,8 @@ auto assembleArchiveCmd()
 
 void log_sentry(sentry_level_t level, const char *message, va_list args, void *)
 {
-    spdlog::level::level_enum log_level = spdlog::level::critical;
+    // TODO:
+    /* spdlog::level::level_enum log_level = spdlog::level::critical;
     switch (level)
     {
     case SENTRY_LEVEL_DEBUG:
@@ -76,7 +77,7 @@ void log_sentry(sentry_level_t level, const char *message, va_list args, void *)
     if (vsnprintf(text, std::size(text), message, args) > 0)
     {
         spdlog::log(log_level, text);
-    }
+    }*/
 }
 
 }

--- a/src/libs/pcs_controls/src/pcs_controls.cpp
+++ b/src/libs/pcs_controls/src/pcs_controls.cpp
@@ -433,7 +433,7 @@ void PCS_CONTROLS::Update(uint32_t DeltaTime)
     nMouseDy = point.y - nMouseYPrev;
 
     RECT r;
-    GetWindowRect(static_cast<HWND>(core.GetAppHWND()), &r);
+    GetWindowRect(static_cast<HWND>(core.GetWindow()->OSHandle()), &r);
     nMouseXPrev = r.left + (r.right - r.left) / 2;
     nMouseYPrev = r.top + (r.bottom - r.top) / 2;
     SetCursorPos(nMouseXPrev, nMouseYPrev);

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -557,7 +557,7 @@ bool DX9RENDER::Init()
         videoAdapterIndex = ini->GetInt(nullptr, "adapter", std::numeric_limits<int32_t>::max());
 
         // stencil_format = D3DFMT_D24S8;
-        if (!InitDevice(bWindow, static_cast<HWND>(core.GetAppHWND()), screen_size.x, screen_size.y))
+        if (!InitDevice(bWindow, static_cast<HWND>(core.GetWindow()->OSHandle()), screen_size.x, screen_size.y))
             return false;
 
 #ifdef _WIN32 // Effects

--- a/src/libs/renderer/src/s_device.h
+++ b/src/libs/renderer/src/s_device.h
@@ -578,7 +578,6 @@ private:
 
     uint32_t dwNumDrawPrimitive, dwNumLV, dwNumLI;
     float fG, fB, fC;
-    D3DGAMMARAMP DefaultRamp;
 
     float fNearClipPlane, fFarClipPlane;
 

--- a/src/libs/window/include/os_window.hpp
+++ b/src/libs/window/include/os_window.hpp
@@ -49,6 +49,8 @@ class OSWindow
     virtual void Resize(int width, int height) = 0;
     //! Set window title
     virtual void SetTitle(const std::string &title) = 0;
+    //! Set window gamma
+    virtual void SetGamma(const uint16_t (&red)[256], const uint16_t (&green)[256], const uint16_t (&blue)[256]) = 0;
 
     //! Subscribe for events
     //! \param handler event callback

--- a/src/libs/window/src/sdl_window.cpp
+++ b/src/libs/window/src/sdl_window.cpp
@@ -81,6 +81,11 @@ void SDLWindow::SetTitle(const std::string &title)
     SDL_SetWindowTitle(window_.get(), title.c_str());
 }
 
+void SDLWindow::SetGamma(const uint16_t (&red)[256], const uint16_t (&green)[256], const uint16_t (&blue)[256])
+{
+    SDL_SetWindowGammaRamp(window_.get(), red, green, blue);
+}
+
 int SDLWindow::Subscribe(const EventHandler &handler)
 {
     int id = 1;
@@ -114,12 +119,12 @@ void *SDLWindow::OSHandle()
 #endif
 }
 
-SDL_Window *SDLWindow::SDLHandle()
+SDL_Window *SDLWindow::SDLHandle() const
 {
     return window_.get();
 }
 
-void SDLWindow::ProcessEvent(const SDL_WindowEvent &evt)
+void SDLWindow::ProcessEvent(const SDL_WindowEvent &evt) const
 {
     Event winEvent;
     switch (evt.event)

--- a/src/libs/window/src/sdl_window.hpp
+++ b/src/libs/window/src/sdl_window.hpp
@@ -24,14 +24,15 @@ class SDLWindow : public OSWindow
     void SetFullscreen(bool fullscreen) override;
     void Resize(int width, int height) override;
     void SetTitle(const std::string &title) override;
+    void SetGamma(const uint16_t (&red)[256], const uint16_t (&green)[256], const uint16_t (&blue)[256]) override;
 
     int Subscribe(const EventHandler &handler) override;
     void Unsubscribe(int id) override;
 
     void *OSHandle() override;
 
-    SDL_Window *SDLHandle();
-    void ProcessEvent(const SDL_WindowEvent &evt);
+    SDL_Window *SDLHandle() const;
+    void ProcessEvent(const SDL_WindowEvent &evt) const;
 
   private:
     static int SDLCALL SDLEventHandler(void *userdata, SDL_Event *evt);

--- a/src/libs/xinterface/src/aviplayer/aviplayer.cpp
+++ b/src/libs/xinterface/src/aviplayer/aviplayer.cpp
@@ -242,7 +242,7 @@ bool CAviPlayer::PlayMedia(const char *fileName)
     }
 
     RECT dstRect;
-    GetWindowRect(static_cast<HWND>(core.GetAppHWND()), &dstRect);
+    GetWindowRect(static_cast<HWND>(core.GetWindow()->OSHandle()), &dstRect);
     auto dstWidth = dstRect.right - dstRect.left;
     auto dstHeight = dstRect.bottom - dstRect.top;
 
@@ -327,7 +327,7 @@ bool CAviPlayer::GetInterfaces()
         core.Trace("Video Error!!! Can`t create DirectDraw interface");
         return false;
     }
-    hr = pDD->SetCooperativeLevel(static_cast<HWND>(core.GetAppHWND()), DDSCL_NORMAL);
+    hr = pDD->SetCooperativeLevel(static_cast<HWND>(core.GetWindow()->OSHandle()), DDSCL_NORMAL);
     if (FAILED(hr))
     {
         core.Trace("Video Error!!! Can`t SetCooperativeLevel for DirectDraw");

--- a/src/libs/xinterface/src/xinterface.cpp
+++ b/src/libs/xinterface/src/xinterface.cpp
@@ -1069,7 +1069,7 @@ void XINTERFACE::LoadIni()
 
 #ifdef _WIN32 // FIX_LINUX GetWindowRect
     RECT Screen_Rect;
-    GetWindowRect(static_cast<HWND>(core.GetAppHWND()), &Screen_Rect);
+    GetWindowRect(static_cast<HWND>(core.GetWindow()->OSHandle()), &Screen_Rect);
 #else
     int sdlScreenWidth, sdlScreenHeight;
     SDL_GetWindowSize(reinterpret_cast<SDL_Window *>(core.GetAppHWND()), &sdlScreenWidth, &sdlScreenHeight);

--- a/src/libs/xinterface/src/xinterface.cpp
+++ b/src/libs/xinterface/src/xinterface.cpp
@@ -1072,7 +1072,7 @@ void XINTERFACE::LoadIni()
     GetWindowRect(static_cast<HWND>(core.GetWindow()->OSHandle()), &Screen_Rect);
 #else
     int sdlScreenWidth, sdlScreenHeight;
-    SDL_GetWindowSize(reinterpret_cast<SDL_Window *>(core.GetAppHWND()), &sdlScreenWidth, &sdlScreenHeight);
+    SDL_GetWindowSize(reinterpret_cast<SDL_Window *>(core.GetWindow()->OSHandle()), &sdlScreenWidth, &sdlScreenHeight);
 #endif
 
     fScale = 1.0f;


### PR DESCRIPTION
mimalloc-redirect is disabled in this PR because of the windows bug: it uses RtlFreeHeap after allocating some resource with malloc which is detoured by mimalloc-redirect. This results in a crash e.g. if  `SetGammaRamp ` or `SetDeviceGammaRamp` is used.
I hope this will be workarounded by mimalloc or fixed by microsoft