### PR TITLE
[worldmap] fix high fps glitches

### DIFF
--- a/src/libs/worldmap/src/wdm_ship.cpp
+++ b/src/libs/worldmap/src/wdm_ship.cpp
@@ -334,9 +334,9 @@ void WdmShip::UpdateWaterMark(float dltTime)
     if (ka > 1.0f)
         ka = 1.0f;
     float ks = inrtSize * dltTime;
-    if (ks > 10.0f)
-        ks = 10.0f;
     ks *= modelW05 * 1.33f;
+    if (ks > 1.0f)
+        ks = 1.0f;
     for (int32_t i = 1; i < WDM_SHIP_WMSZ; i++)
     {
         lines[i].x += (lines[i - 1].x - lines[i].x) * kp;


### PR DESCRIPTION
There was a value used for vertex pos calculation which increased in geometric progression. If fps was high enough this caused glitches similar to this
![2022-09-10_16-48-16](https://user-images.githubusercontent.com/26986655/192112434-d3aacec5-ffc9-440d-a465-22b0c14cff46.png)
