### PR TITLE
sea_ai: support HeightMultiply for balls

### DIFF
--- a/src/libs/sea_ai/src/ai_balls.h
+++ b/src/libs/sea_ai/src/ai_balls.h
@@ -24,6 +24,7 @@ struct BALL_PARAMS
     float fSizeMultiply;      // Size of ball multiply
     float fTimeSpeedMultiply; // Time speed multiply
     float fMaxFireDistance;
+    float fRawAng;
     uint32_t dwCannonType; // Additional parameter
 };
 

--- a/src/libs/sea_ai/src/ai_cannon.cpp
+++ b/src/libs/sea_ai/src/ai_cannon.cpp
@@ -131,8 +131,8 @@ void AICannon::RealFire()
     if (vEnemyPos.y < vPosTemp.y)
         fAngle = -fAngle;
 
-    core.Event(CANNON_FIRE, "affffffff", pAHolder->GetACharacter(), vPosTemp.x, vPosTemp.y, vPosTemp.z, fSpeedV0,
-               fFireDirection, fFireHeightAngle, fAngle, fMaxFireDistance);
+    core.Event(CANNON_FIRE, "afffffffff", pAHolder->GetACharacter(), vPosTemp.x, vPosTemp.y, vPosTemp.z, fSpeedV0,
+               fFireDirection, fFireHeightAngle, fDirY, fMaxFireDistance, fAngle);
 
     pAIObj->Fire(*pAIObj->GetMatrix() * (vPos + vDir));
 

--- a/src/libs/sea_ai/src/ai_cannon.cpp
+++ b/src/libs/sea_ai/src/ai_cannon.cpp
@@ -4,8 +4,7 @@
 
 uint64_t dwTmpRDTSC;
 
-AICannon::AICannon()
-    : pAHolder(nullptr), eidParent(0), vPos(), vDir(), fSpeedV0(0), vEnemyPos()
+AICannon::AICannon() : pAHolder(nullptr), eidParent(0), vPos(), vDir(), fSpeedV0(0), vEnemyPos()
 {
     bLoad = false;
     bEmpty = true;
@@ -125,8 +124,15 @@ void AICannon::RealFire()
 
     const auto vDirTemp = mRot * vDir;
     const auto fDirY = NormalizeAngle(atan2f(vDirTemp.x, vDirTemp.z));
+
+    // raw angle
+    const CVECTOR vFlatEnemyDir = !(CVECTOR(vEnemyPos.x, vPosTemp.y, vEnemyPos.z) - vPosTemp);
+    float fAngle = acosf(vFlatEnemyDir | vEnemyDir);
+    if (vEnemyPos.y < vPosTemp.y)
+        fAngle = -fAngle;
+
     core.Event(CANNON_FIRE, "affffffff", pAHolder->GetACharacter(), vPosTemp.x, vPosTemp.y, vPosTemp.z, fSpeedV0,
-               fFireDirection, fFireHeightAngle, fDirY, fMaxFireDistance);
+               fFireDirection, fFireHeightAngle, fAngle, fMaxFireDistance);
 
     pAIObj->Fire(*pAIObj->GetMatrix() * (vPos + vDir));
 


### PR DESCRIPTION
logical continuation of #321 

- originally height was calculated incorrectly, making HeightMultiply unusable
- in stock COAS there is a cannon with a custom multiplier=0.6; this also should fix trajectories for it