### PR TITLE
[core] rework script cache

### DIFF
--- a/src/libs/core/include/file_service.h
+++ b/src/libs/core/include/file_service.h
@@ -127,4 +127,6 @@ class FILE_SERVICE : public VFILE_SERVICE
     void AddEntryToResourcePaths(const std::filesystem::directory_entry &entry, std::string &CheckingPath);
     void ScanResourcePaths() override;
     std::string ConvertPathResource(const char *path) override;
+
+    uint64_t GetPathFingerprint(const std::filesystem::path &path) override;
 };

--- a/src/libs/core/include/v_file_service.h
+++ b/src/libs/core/include/v_file_service.h
@@ -58,6 +58,8 @@ class VFILE_SERVICE
     // Resource paths
     virtual void ScanResourcePaths() = 0;
     virtual std::string ConvertPathResource(const char *path) = 0;
+
+    virtual uint64_t GetPathFingerprint(const std::filesystem::path& path) = 0;
 };
 
 //------------------------------------------------------------------------------------------------

--- a/src/libs/core/src/compiler.h
+++ b/src/libs/core/src/compiler.h
@@ -234,7 +234,7 @@ class COMPILER : public VIRTUAL_COMPILER
 
     void CopyOffsets(SEGMENT_DESC &Segment, STRINGS_LIST &srclist, STRINGS_LIST &dstlist, const char *sname);
 
-    void FormatDialog(char *file_name);
+    void FormatDialog(const char *file_name);
     void FormatAllDialog(const char *directory_name);
 
     // bool SetSaveData(const char * file_name, const char * save_data);
@@ -270,23 +270,23 @@ class COMPILER : public VIRTUAL_COMPILER
 private:
     [[nodiscard]] std::filesystem::path GetSegmentCachePath(const SEGMENT_DESC &segment) const;
 
+    uint64_t cache_fingerprint_{};
+    
     bool LoadSegmentFromCache(SEGMENT_DESC &segment);
-    bool LoadFilesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
-    void LoadDefinesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
-    void LoadVariablesFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
-    void LoadFunctionsFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
-    void LoadScriptLibrariesFromCache(storm::script_cache::Reader &reader);
-    void LoadEventHandlersFromCache(storm::script_cache::Reader &reader);
-    void LoadByteCodeFromCache(storm::script_cache::Reader &reader, SEGMENT_DESC &segment);
+    void LoadDefinesFromCache(storm::script_cache::BufferReader &reader, SEGMENT_DESC &segment);
+    void LoadVariablesFromCache(storm::script_cache::BufferReader &reader, SEGMENT_DESC &segment);
+    void LoadFunctionsFromCache(storm::script_cache::BufferReader &reader, SEGMENT_DESC &segment);
+    void LoadScriptLibrariesFromCache(storm::script_cache::BufferReader &reader);
+    void LoadEventHandlersFromCache(storm::script_cache::BufferReader &reader);
+    void LoadByteCodeFromCache(storm::script_cache::BufferReader &reader, SEGMENT_DESC &segment);
 
     void SaveSegmentToCache(const SEGMENT_DESC &segment);
-    void SaveFilesToCache(storm::script_cache::Writer &writer);
-    void SaveDefinesToCache(storm::script_cache::Writer &writer);
-    void SaveVariablesToCache(storm::script_cache::Writer &writer);
-    void SaveFunctionsToCache(storm::script_cache::Writer &writer);
-    void SaveScriptLibrariesToCache(storm::script_cache::Writer &writer);
-    void SaveEventHandlersToCache(storm::script_cache::Writer &writer);
-    void SaveByteCodeToCache(storm::script_cache::Writer &writer, const SEGMENT_DESC &segment);
+    void SaveDefinesToCache(storm::script_cache::BufferWriter &writer);
+    void SaveVariablesToCache(storm::script_cache::BufferWriter &writer);
+    void SaveFunctionsToCache(storm::script_cache::BufferWriter &writer);
+    void SaveScriptLibrariesToCache(storm::script_cache::BufferWriter &writer);
+    void SaveEventHandlersToCache(storm::script_cache::BufferWriter &writer);
+    void SaveByteCodeToCache(storm::script_cache::BufferWriter &writer, const SEGMENT_DESC &segment);
 
     COMPILER_STAGE CompilerStage;
     STRINGS_LIST LabelTable;
@@ -366,6 +366,6 @@ private:
     storm::ringbuffer_stack<std::tuple<const char *, size_t, const char *>, CALLSTACK_SIZE> callStack_;
 
     // attempt to read/write script cache?
-    bool use_script_cache_;
+    int script_cache_mode_;
     storm::ScriptCache script_cache_;
 };

--- a/src/libs/core/src/file_service.cpp
+++ b/src/libs/core/src/file_service.cpp
@@ -512,6 +512,29 @@ std::string FILE_SERVICE::ConvertPathResource(const char *path)
 #endif
 }
 
+uint64_t FILE_SERVICE::GetPathFingerprint(const std::filesystem::path &path)
+{
+    uint64_t result = 0U;
+
+    if (exists(path))
+    {
+        if (is_directory(path))
+        {
+            for (const auto &entry : std::filesystem::directory_iterator(path))
+            {
+                result += GetPathFingerprint(entry);
+            }
+        }
+        else if (is_regular_file(path))
+        {
+            const auto timestamp = last_write_time(path).time_since_epoch().count();
+            result += timestamp;
+        }
+    }
+    
+    return result;
+}
+
 //=================================================================================================
 
 INIFILE_T::~INIFILE_T()

--- a/src/libs/core/src/script_cache.cpp
+++ b/src/libs/core/src/script_cache.cpp
@@ -1,0 +1,87 @@
+#include "script_cache.h"
+
+storm::script_cache::ReaderException::ReaderException()
+    : std::runtime_error("Unable to read binary data. Scripts mismatch?")
+{
+}
+
+storm::script_cache::BufferReader::BufferReader(std::vector<char> &&buffer)
+    : buffer_(std::move(buffer)), cur_pointer_(0)
+{
+}
+
+std::string_view storm::script_cache::BufferReader::ReadArray()
+{
+    const auto buffer_size = Read<size_t>();
+    if (buffer_size == 0)
+    {
+        return {};
+    }
+    if (cur_pointer_ + buffer_size > std::size(buffer_))
+    {
+        throw ReaderException();
+    }
+
+    const std::string_view sv{std::data(buffer_) + cur_pointer_, buffer_size};
+    cur_pointer_ += buffer_size;
+
+    return sv;
+}
+
+void storm::script_cache::BufferWriter::WriteArray(std::string_view data)
+{
+    buffer_.reserve(std::size(buffer_) + sizeof(decltype(std::size(data))) + std::size(data));
+    WriteData(std::size(data));
+    std::ranges::copy(data, std::back_inserter(buffer_));
+}
+
+std::string_view storm::script_cache::BufferWriter::GetDataBuffer() const noexcept
+{
+    return {std::data(buffer_), std::size(buffer_)};
+}
+
+void storm::script_cache::ReadScriptData(BufferReader &reader, S_TOKEN_TYPE type, DATA *data)
+{
+    switch (type)
+    {
+    case VAR_INTEGER: {
+        const auto value = reader.Read<int32_t>();
+        data->Set(value);
+        break;
+    }
+
+    case VAR_FLOAT: {
+        const auto value = reader.Read<float>();
+        data->Set(value);
+        break;
+    }
+    case VAR_STRING: {
+        const auto value = reader.ReadArray();
+        data->Set(std::string(value));
+        break;
+    }
+    }
+}
+
+void storm::script_cache::WriteScriptData(BufferWriter &writer, S_TOKEN_TYPE type, DATA *data)
+{
+    switch (type)
+    {
+    case VAR_INTEGER: {
+        const auto value = data->GetInt();
+        writer.WriteData(value);
+        break;
+    }
+
+    case VAR_FLOAT: {
+        const auto value = data->GetFloat();
+        writer.WriteData(value);
+        break;
+    }
+    case VAR_STRING: {
+        const auto value = data->GetString();
+        writer.WriteArray(value);
+        break;
+    }
+    }
+}


### PR DESCRIPTION
- invalidation depends on folder content timestamp instead of corresponding file hash
- generic refactoring and bug fixing
- `use_cache{true|false}` changed to `cache_mode{0|1|2}` 0 - disabled
1 - enabled, integrity calculated on each script load 2 - enabled, integrity calculated once on start

'1' recommended for development, e.g. interface script tuning 
'2' recommended for release