### PR TITLE
[ci] fix installing xorg/system requirements

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -53,6 +53,9 @@ jobs:
         export CXX=clang++-${{matrix.clang_version}}
         ${CXX} --version
         mkdir build && cd build
+        conan profile new default --detect
+        conan profile update conf.tools.system.package_manager:mode=install default
+        conan profile update conf.tools.system.package_manager:sudo=True default
         cmake .. -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.configuration}}
     - name: Build dependencies
       run: ninja dependencies


### PR DESCRIPTION
If you will check last Linux CI build - there is error:
https://github.com/storm-devs/storm-engine/actions/runs/3272758555/jobs/5384162981
```
xorg/system: ERROR: while executing system_requirements(): System requirements: 'xtrans-dev, xkb-data' are missing but
can't install because tools.system.package_manager:mode is 'check'.Please update packages manually or set
'tools.system.package_manager:mode' to 'install' in the [conf] section of the profile, or in the command line
using '-c tools.system.package_manager:mode=install'
ERROR: Error in system requirements
```
This PR contain fix for it.