### PR TITLE
Improve slide_line behavior

### DIFF
--- a/src/libs/xinterface/src/nodes/xi_slide_line.cpp
+++ b/src/libs/xinterface/src/nodes/xi_slide_line.cpp
@@ -184,12 +184,18 @@ void CXI_SLIDELINE::DoMouseControl()
     if (m_bDoChangeSlider)
     {
         if (fmp.x < m_rect.left + m_nBaseLeft)
-            SetNewValue(0);
+        {    
+            SetNewValue(m_nCurValue - 1);
+        }    
         else if (fmp.x > m_rect.right - m_nBaseLeft)
-            SetNewValue(m_nGrateQuantity);
+        {    
+            SetNewValue(m_nCurValue + 1);
+        }    
         else
+        {    
             SetNewValue(static_cast<int32_t>((fmp.x - m_rect.left - m_nBaseLeft) /
                                           (m_rect.right - m_rect.left - m_nBaseLeft - m_nBaseLeft) * m_nGrateQuantity));
+        }
     }
 }
 


### PR DESCRIPTION
Current slide_line behavior is strange: if you click 1 time on arrow on slide_line - it will chnange position to min (0) or max (m_nGrateQuantity):
![old](https://user-images.githubusercontent.com/1950719/197411712-eacd7909-36c7-413b-8d91-a28565b8e7bf.gif)

@ugeen4 improved slide_line behavior in Legendary Edition. I think it works better now and I would like to use it in TEHO:
![new](https://user-images.githubusercontent.com/1950719/197411752-23464b8a-84fa-4c16-849a-f063a630bf9b.gif)

