### PR TITLE
worldmap: simplify calculation of food and rum position in wdm_wind_ui

### DIFF
--- a/src/libs/worldmap/src/wdm_wind_ui.cpp
+++ b/src/libs/worldmap/src/wdm_wind_ui.cpp
@@ -277,7 +277,7 @@ void WdmWindUI::LRender(VDX9RENDER *rs)
     DrawRects(buf, 1, "WdmDrawMapBlend");
 
     // write the number of supplies
-    float foodRumSpacing = rum ? 24.0f : 0.0f;
+    float foodRumSpacing = 24.0f;
 
     sprintf_s(tbuf, sizeof(tbuf) - 1, "%i%s", food > 99999 ? 99999 : food, food > 99999 ? "+" : "");
     tbuf[sizeof(tbuf) - 1] = 0;
@@ -286,16 +286,12 @@ void WdmWindUI::LRender(VDX9RENDER *rs)
     rs->ExtPrint(font, 0xffffffff, 0x00000000, PR_ALIGN_CENTER, true, resizeRatio, 0, 0,
                  int32_t(cx - foodRumSpacing * resizeRatio), int32_t(cy + 30.0f * resizeRatio), tbuf);
 
-    // write the amount of rum
-    if (rum)
-    {
-        snprintf(tbuf, sizeof(tbuf) - 1, "%i", rum.value());
-        tbuf[sizeof(tbuf) - 1] = 0;
-        fw = rs->StringWidth(tbuf, font, resizeRatio, static_cast<int32_t>(w));
+    snprintf(tbuf, sizeof(tbuf) - 1, "%i", rum.value());
+    tbuf[sizeof(tbuf) - 1] = 0;
+    fw = rs->StringWidth(tbuf, font, resizeRatio, static_cast<int32_t>(w));
 
-        rs->ExtPrint(font, 0xffffffff, 0x00000000, PR_ALIGN_CENTER, true, resizeRatio, 0, 0,
-                     int32_t(cx + foodRumSpacing * resizeRatio), int32_t(cy + 30.0f * resizeRatio), tbuf);
-    }
+    rs->ExtPrint(font, 0xffffffff, 0x00000000, PR_ALIGN_CENTER, true, resizeRatio, 0, 0,
+                 int32_t(cx + foodRumSpacing * resizeRatio), int32_t(cy + 30.0f * resizeRatio), tbuf);
 
     if (!wdmObjects->coordinate.empty())
     {


### PR DESCRIPTION
`rum` is `std::optional<int32_t>` and when `rum == 0` we still has `if (rum)` - true. So there was 2 options: remove this check or replace it with `if (rum != 0)`, but if i'll use `if (rum != 0)` - i get this behavior:
![rum-0-wrong](https://user-images.githubusercontent.com/1950719/199996389-510df931-e4c1-4d5c-ae15-d282f7d72c89.png)
Which is wrong and looks bad.
I checked if it's possible to hide rum icon, but it's grouped with few other
(check `resource\Textures\WorldMap\Interfaces\MORALE.tga.tx`):
![ConvTX](https://user-images.githubusercontent.com/1950719/199997418-338c3512-772c-4f9d-bd11-52011daf2443.png)

So, I suggest to remove 2 useless checks.