### PR TITLE
Replace few Windows only types

### DIFF
--- a/src/libs/battle_interface/src/image/img_render.cpp
+++ b/src/libs/battle_interface/src/image/img_render.cpp
@@ -2,6 +2,8 @@
 #include "storm_assert.h"
 #include "string.h"
 
+#include <algorithm>
+
 BIImageRender::BIImageRender(VDX9RENDER *pRS)
     : m_nBeginOutputPrioritet(0), m_nEndOutputPrioritet(0)
 {

--- a/src/libs/core/include/v_file_service.h
+++ b/src/libs/core/include/v_file_service.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <windows.h>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>

--- a/src/libs/core/src/core_impl.h
+++ b/src/libs/core/src/core_impl.h
@@ -8,8 +8,6 @@
 #include "timer.h"
 #include "vma.hpp"
 
-#include <windows.h>
-
 #define ENGINE_SCRIPT_VERSION 54128
 
 class CoreImpl final : public CorePrivate

--- a/src/libs/lighter/src/l_geometry.cpp
+++ b/src/libs/lighter/src/l_geometry.cpp
@@ -199,7 +199,7 @@ bool LGeometry::Process(VDX9RENDER *rs, int32_t numLights)
             }
             // Copy
             uint8_t *pnt = nullptr;
-            if (vbuf->Lock(0, desc.Size, (VOID **)&pnt, 0) != D3D_OK)
+            if (vbuf->Lock(0, desc.Size, (void **)&pnt, 0) != D3D_OK)
             {
                 core.Trace("Location lighter: vertex buffer no locked, model %s, vbID %i", object[i].nameReal, vbID);
                 return false;

--- a/src/libs/location/src/supervisor.h
+++ b/src/libs/location/src/supervisor.h
@@ -9,6 +9,7 @@
 // ============================================================================================
 
 #pragma once
+#include <cstdint>
 #include <vector>
 
 class Character;

--- a/src/libs/model/src/model.cpp
+++ b/src/libs/model/src/model.cpp
@@ -67,7 +67,7 @@ void *VBTransform(void *vb, int32_t startVrt, int32_t nVerts, int32_t totVerts)
     auto *src = static_cast<GEOS::AVERTEX0 *>(vb);
 
     GEOS::VERTEX0 *dst;
-    dest_vb->Lock(0, 0, (VOID **)&dst, D3DLOCK_DISCARD | D3DLOCK_NOSYSLOCK);
+    dest_vb->Lock(0, 0, (void **)&dst, D3DLOCK_DISCARD | D3DLOCK_NOSYSLOCK);
 
 #ifndef _WIN32 // FIX_LINUX DirectXMath
     CMatrix mtx;

--- a/src/libs/renderer/include/dx9render.h
+++ b/src/libs/renderer/include/dx9render.h
@@ -203,7 +203,7 @@ class VDX9RENDER : public SERVICE
     virtual void SaveShoot() = 0;
 
     // DX9Render: Clip Planes Section
-    virtual HRESULT SetClipPlane(uint32_t Index, CONST float *pPlane) = 0;
+    virtual HRESULT SetClipPlane(uint32_t Index, const float *pPlane) = 0;
     virtual PLANE *GetPlanes() = 0;
 
     // DX9Render: Camera Section
@@ -342,32 +342,32 @@ class VDX9RENDER : public SERVICE
     virtual HRESULT GetLevelDesc(IDirect3DTexture9 *ppTexture, UINT Level, D3DSURFACE_DESC *pDesc) = 0;
     virtual HRESULT GetLevelDesc(IDirect3DCubeTexture9 *ppCubeTexture, UINT Level, D3DSURFACE_DESC *pDesc) = 0;
     virtual HRESULT LockRect(IDirect3DCubeTexture9 *ppCubeTexture, D3DCUBEMAP_FACES FaceType, UINT Level,
-                             D3DLOCKED_RECT *pLockedRect, CONST RECT *pRect, uint32_t Flags) = 0;
-    virtual HRESULT LockRect(IDirect3DTexture9 *ppTexture, UINT Level, D3DLOCKED_RECT *pLockedRect, CONST RECT *pRect,
+                             D3DLOCKED_RECT *pLockedRect, const RECT *pRect, uint32_t Flags) = 0;
+    virtual HRESULT LockRect(IDirect3DTexture9 *ppTexture, UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect,
                              uint32_t Flags) = 0;
     virtual HRESULT UnlockRect(IDirect3DCubeTexture9 *pCubeTexture, D3DCUBEMAP_FACES FaceType, UINT Level) = 0;
     virtual HRESULT UnlockRect(IDirect3DTexture9 *pTexture, UINT Level) = 0;
     virtual HRESULT GetSurfaceLevel(IDirect3DTexture9 *ppTexture, UINT Level, IDirect3DSurface9 **ppSurfaceLevel) = 0;
-    virtual HRESULT UpdateSurface(IDirect3DSurface9 *pSourceSurface, CONST RECT *pSourceRectsArray, UINT cRects,
-                                  IDirect3DSurface9 *pDestinationSurface, CONST POINT *pDestPointsArray) = 0;
+    virtual HRESULT UpdateSurface(IDirect3DSurface9 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects,
+                                  IDirect3DSurface9 *pDestinationSurface, const POINT *pDestPointsArray) = 0;
     virtual HRESULT StretchRect(IDirect3DSurface9 *pSourceSurface, const RECT *pSourceRect,
                                 IDirect3DSurface9 *pDestSurface, const RECT *pDestRect,
                                 D3DTEXTUREFILTERTYPE Filter) = 0;
     virtual HRESULT GetRenderTargetData(IDirect3DSurface9 *pRenderTarget, IDirect3DSurface9 *pDestSurface) = 0;
 
     // D3D Pixel/Vertex Shaders Section
-    virtual HRESULT CreateVertexDeclaration(CONST D3DVERTEXELEMENT9 *pVertexElements,
+    virtual HRESULT CreateVertexDeclaration(const D3DVERTEXELEMENT9 *pVertexElements,
                                             IDirect3DVertexDeclaration9 **ppDecl) = 0;
     virtual HRESULT SetVertexDeclaration(IDirect3DVertexDeclaration9 *pDecl) = 0;
-    virtual HRESULT CreatePixelShader(CONST uint32_t *pFunction, IDirect3DPixelShader9 **ppShader) = 0;
-    virtual HRESULT CreateVertexShader(CONST uint32_t *pFunction, IDirect3DVertexShader9 **ppShader) = 0;
+    virtual HRESULT CreatePixelShader(const uint32_t *pFunction, IDirect3DPixelShader9 **ppShader) = 0;
+    virtual HRESULT CreateVertexShader(const uint32_t *pFunction, IDirect3DVertexShader9 **ppShader) = 0;
     virtual HRESULT DeletePixelShader(IDirect3DPixelShader9 *pShader) = 0;
     virtual HRESULT DeleteVertexShader(IDirect3DVertexShader9 *pShader) = 0;
     virtual HRESULT SetVertexShader(IDirect3DVertexShader9 *pShader) = 0;
     virtual HRESULT SetPixelShader(IDirect3DPixelShader9 *pShader) = 0;
-    /*virtual HRESULT SetFVFConstant(DWORD Register, CONST void * pConstantData, DWORD  ConstantCount ) = 0;*/
-    virtual HRESULT SetVertexShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4iCount) = 0;
-    virtual HRESULT SetPixelShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4iCount) = 0;
+    /*virtual HRESULT SetFVFConstant(DWORD Register, const void * pConstantData, DWORD  ConstantCount ) = 0;*/
+    virtual HRESULT SetVertexShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4iCount) = 0;
+    virtual HRESULT SetPixelShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4iCount) = 0;
     virtual HRESULT SetFVF(uint32_t handle) = 0;
     virtual HRESULT GetVertexShader(IDirect3DVertexShader9 **ppShader) = 0;
     virtual HRESULT GetPixelShader(IDirect3DPixelShader9 **ppShader) = 0;
@@ -378,7 +378,7 @@ class VDX9RENDER : public SERVICE
     // D3D Render Target/Begin/End/Clear
     virtual HRESULT GetRenderTarget(IDirect3DSurface9 **ppRenderTarget) = 0;
     virtual HRESULT SetRenderTarget(IDirect3DSurface9 *pRenderTarget, IDirect3DSurface9 *pNewZStencil) = 0;
-    virtual HRESULT Clear(uint32_t Count, CONST D3DRECT *pRects, uint32_t Flags, D3DCOLOR Color, float Z,
+    virtual HRESULT Clear(uint32_t Count, const D3DRECT *pRects, uint32_t Flags, D3DCOLOR Color, float Z,
                           uint32_t Stencil) = 0;
     virtual HRESULT BeginScene() = 0;
     virtual HRESULT EndScene() = 0;

--- a/src/libs/renderer/src/font.cpp
+++ b/src/libs/renderer/src/font.cpp
@@ -164,7 +164,7 @@ bool FONT::Init(const char *font_name, const char *iniName)
                                nullptr);
     if (vertexBuffer_ == nullptr)
         throw std::runtime_error("vbuffer error");
-    vertexBuffer_->Lock(0, sizeof(FONT_CHAR_VERTEX) * MAX_SYMBOLS * SYM_VERTEXS, (VOID **)&pVertex, 0);
+    vertexBuffer_->Lock(0, sizeof(FONT_CHAR_VERTEX) * MAX_SYMBOLS * SYM_VERTEXS, (void **)&pVertex, 0);
     for (codepoint = 0; codepoint < MAX_SYMBOLS * SYM_VERTEXS; codepoint++)
     {
         pVertex[codepoint].pos.z = 0.5f;
@@ -229,7 +229,7 @@ int32_t FONT::UpdateVertexBuffer(int32_t x, int32_t y, char *data_PTR, int utf8l
 
     s_num = strlen(data_PTR);
 
-    vertexBuffer_->Lock(0, sizeof(FONT_CHAR_VERTEX) * utf8length * SYM_VERTEXS, (VOID **)&pVertex, 0);
+    vertexBuffer_->Lock(0, sizeof(FONT_CHAR_VERTEX) * utf8length * SYM_VERTEXS, (void **)&pVertex, 0);
 
     xoffset = 0;
 

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -1252,7 +1252,7 @@ bool DX9RENDER::DX9EndScene()
     if (bDropVideoConveyor && pDropConveyorVBuffer)
     {
         CVECTOR *pV;
-        pDropConveyorVBuffer->Lock(0, 0, (VOID **)&pV, 0);
+        pDropConveyorVBuffer->Lock(0, 0, (void **)&pV, 0);
         for (int32_t i = 0; i < 2; i++)
             pV[i] = CVECTOR(1e6f, 1e6f, 1e6f);
         pDropConveyorVBuffer->Unlock();
@@ -2373,7 +2373,7 @@ void DX9RENDER::RenderAnimation(int32_t ib, void *src, int32_t numVrts, int32_t 
         // Copy verteces
         uint8_t *ptr;
         RDTSC_B(_rdtsc);
-        if (CHECKD3DERR(aniVBuffer->Lock(0, size, (VOID **)&ptr, 0)) == true)
+        if (CHECKD3DERR(aniVBuffer->Lock(0, size, (void **)&ptr, 0)) == true)
             return;
         dwNumLV++;
         RDTSC_E(_rdtsc);
@@ -2400,7 +2400,7 @@ void *DX9RENDER::LockVertexBuffer(int32_t id, uint32_t dwFlags)
 {
     uint8_t *ptr;
     VertexBuffers[id].dwNumLocks++;
-    if (CHECKD3DERR(VertexBuffers[id].buff->Lock(0, VertexBuffers[id].size, (VOID **)&ptr, dwFlags)))
+    if (CHECKD3DERR(VertexBuffers[id].buff->Lock(0, VertexBuffers[id].size, (void **)&ptr, dwFlags)))
         return nullptr;
 
     dwNumLV++;
@@ -2423,7 +2423,7 @@ void *DX9RENDER::LockIndexBuffer(int32_t id, uint32_t dwFlags)
 {
     uint8_t *ptr = nullptr;
     IndexBuffers[id].dwNumLocks++;
-    if (CHECKD3DERR(IndexBuffers[id].buff->Lock(0, IndexBuffers[id].size, (VOID **)&ptr, dwFlags)))
+    if (CHECKD3DERR(IndexBuffers[id].buff->Lock(0, IndexBuffers[id].size, (void **)&ptr, dwFlags)))
         return nullptr;
 
     dwNumLI++;
@@ -3429,7 +3429,7 @@ void DX9RENDER::DrawRects(RS_RECT *pRSR, uint32_t dwRectsNum, const char *cBlock
             drawCount = rectsVBuffer_SizeInRects;
         // Buffer
         RECT_VERTEX *data = nullptr;
-        if (rectsVBuffer->Lock(0, drawCount * 6 * sizeof(RECT_VERTEX), (VOID **)&data, D3DLOCK_DISCARD) != D3D_OK)
+        if (rectsVBuffer->Lock(0, drawCount * 6 * sizeof(RECT_VERTEX), (void **)&data, D3DLOCK_DISCARD) != D3D_OK)
             return;
         if (!data)
             return;
@@ -3581,7 +3581,7 @@ HRESULT DX9RENDER::VBLock(IDirect3DVertexBuffer9 *pVB, UINT OffsetToLock, UINT S
                           uint32_t Flags)
 {
     dwNumLV++;
-    return CHECKD3DERR(pVB->Lock(OffsetToLock, SizeToLock, (VOID **)ppbData, Flags));
+    return CHECKD3DERR(pVB->Lock(OffsetToLock, SizeToLock, (void **)ppbData, Flags));
 }
 
 void DX9RENDER::VBUnlock(IDirect3DVertexBuffer9 *pVB)
@@ -3646,7 +3646,7 @@ HRESULT DX9RENDER::SetRenderTarget(IDirect3DSurface9 *pRenderTarget, IDirect3DSu
     return result ? D3D_OK : S_FALSE;
 }
 
-HRESULT DX9RENDER::Clear(uint32_t Count, CONST D3DRECT *pRects, uint32_t Flags, D3DCOLOR Color, float Z,
+HRESULT DX9RENDER::Clear(uint32_t Count, const D3DRECT *pRects, uint32_t Flags, D3DCOLOR Color, float Z,
                          uint32_t Stencil)
 {
     return CHECKD3DERR(d3d9->Clear(Count, pRects, Flags, Color, Z, Stencil));
@@ -3676,7 +3676,7 @@ HRESULT DX9RENDER::EndScene()
     return D3D_OK;
 }
 
-HRESULT DX9RENDER::SetClipPlane(uint32_t Index, CONST float *pPlane)
+HRESULT DX9RENDER::SetClipPlane(uint32_t Index, const float *pPlane)
 {
     // return d3d9->SetClipPlane( Index, pPlane );
     return D3D_OK;
@@ -3707,7 +3707,7 @@ HRESULT DX9RENDER::CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT 
     return CHECKD3DERR(d3d9->CreateDepthStencilSurface(Width, Height, Format, MultiSample, 0, TRUE, ppSurface, NULL));
 }
 
-HRESULT DX9RENDER::CreateVertexDeclaration(CONST D3DVERTEXELEMENT9 *pVertexElements,
+HRESULT DX9RENDER::CreateVertexDeclaration(const D3DVERTEXELEMENT9 *pVertexElements,
                                            IDirect3DVertexDeclaration9 **ppDecl)
 {
     return CHECKD3DERR(d3d9->CreateVertexDeclaration(pVertexElements, ppDecl));
@@ -3718,12 +3718,12 @@ HRESULT DX9RENDER::SetVertexDeclaration(IDirect3DVertexDeclaration9 *pDecl)
     return CHECKD3DERR(d3d9->SetVertexDeclaration(pDecl));
 }
 
-HRESULT DX9RENDER::CreateVertexShader(CONST uint32_t *pFunction, IDirect3DVertexShader9 **ppShader)
+HRESULT DX9RENDER::CreateVertexShader(const uint32_t *pFunction, IDirect3DVertexShader9 **ppShader)
 {
     return CHECKD3DERR(d3d9->CreateVertexShader((const DWORD *)pFunction, ppShader));
 }
 
-HRESULT DX9RENDER::CreatePixelShader(CONST uint32_t *pFunction, IDirect3DPixelShader9 **ppShader)
+HRESULT DX9RENDER::CreatePixelShader(const uint32_t *pFunction, IDirect3DPixelShader9 **ppShader)
 {
     return CHECKD3DERR(d3d9->CreatePixelShader((const DWORD *)pFunction, ppShader));
 }
@@ -3779,12 +3779,12 @@ HRESULT DX9RENDER::GetLevelDesc(IDirect3DCubeTexture9 *ppCubeTexture, UINT Level
 }
 
 HRESULT DX9RENDER::LockRect(IDirect3DCubeTexture9 *ppCubeTexture, D3DCUBEMAP_FACES FaceType, UINT Level,
-                            D3DLOCKED_RECT *pLockedRect, CONST RECT *pRect, uint32_t Flags)
+                            D3DLOCKED_RECT *pLockedRect, const RECT *pRect, uint32_t Flags)
 {
     return CHECKD3DERR(ppCubeTexture->LockRect(FaceType, Level, pLockedRect, pRect, Flags));
 }
 
-HRESULT DX9RENDER::LockRect(IDirect3DTexture9 *ppTexture, UINT Level, D3DLOCKED_RECT *pLockedRect, CONST RECT *pRect,
+HRESULT DX9RENDER::LockRect(IDirect3DTexture9 *ppTexture, UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect,
                             uint32_t Flags)
 {
     return CHECKD3DERR(ppTexture->LockRect(Level, pLockedRect, pRect, Flags));
@@ -3805,8 +3805,8 @@ HRESULT DX9RENDER::GetSurfaceLevel(IDirect3DTexture9 *ppTexture, UINT Level, IDi
     return CHECKD3DERR(ppTexture->GetSurfaceLevel(Level, ppSurfaceLevel));
 }
 
-HRESULT DX9RENDER::UpdateSurface(IDirect3DSurface9 *pSourceSurface, CONST RECT *pSourceRectsArray, UINT cRects,
-                                 IDirect3DSurface9 *pDestinationSurface, CONST POINT *pDestPointsArray)
+HRESULT DX9RENDER::UpdateSurface(IDirect3DSurface9 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects,
+                                 IDirect3DSurface9 *pDestinationSurface, const POINT *pDestPointsArray)
 {
     return CHECKD3DERR(D3DXLoadSurfaceFromSurface(pDestinationSurface, nullptr, nullptr, pSourceSurface, nullptr,
                                                   nullptr, D3DX_DEFAULT, 0));
@@ -3872,12 +3872,12 @@ HRESULT DX9RENDER::SetPixelShader(IDirect3DPixelShader9 *pShader)
     return CHECKD3DERR(d3d9->SetPixelShader(pShader));
 }
 
-HRESULT DX9RENDER::SetVertexShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4iCount)
+HRESULT DX9RENDER::SetVertexShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4iCount)
 {
     return CHECKD3DERR(d3d9->SetVertexShaderConstantF(StartRegister, pConstantData, Vector4iCount));
 }
 
-HRESULT DX9RENDER::SetPixelShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4iCount)
+HRESULT DX9RENDER::SetPixelShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4iCount)
 {
     return CHECKD3DERR(d3d9->SetPixelShaderConstantF(StartRegister, pConstantData, Vector4iCount));
 }

--- a/src/libs/renderer/src/s_device.h
+++ b/src/libs/renderer/src/s_device.h
@@ -139,7 +139,7 @@ class DX9RENDER : public VDX9RENDER
     void SaveShoot() override;
 
     // DX9Render: Clip Planes Section
-    HRESULT SetClipPlane(uint32_t Index, CONST float *pPlane) override;
+    HRESULT SetClipPlane(uint32_t Index, const float *pPlane) override;
     PLANE *GetPlanes() override;
 
     // DX9Render: Camera Section
@@ -281,31 +281,31 @@ class DX9RENDER : public VDX9RENDER
     HRESULT GetLevelDesc(IDirect3DTexture9 *ppTexture, UINT Level, D3DSURFACE_DESC *pDesc) override;
     HRESULT GetLevelDesc(IDirect3DCubeTexture9 *ppCubeTexture, UINT Level, D3DSURFACE_DESC *pDesc) override;
     HRESULT LockRect(IDirect3DCubeTexture9 *ppCubeTexture, D3DCUBEMAP_FACES FaceType, UINT Level,
-                     D3DLOCKED_RECT *pLockedRect, CONST RECT *pRect, uint32_t Flags) override;
-    HRESULT LockRect(IDirect3DTexture9 *ppTexture, UINT Level, D3DLOCKED_RECT *pLockedRect, CONST RECT *pRect,
+                     D3DLOCKED_RECT *pLockedRect, const RECT *pRect, uint32_t Flags) override;
+    HRESULT LockRect(IDirect3DTexture9 *ppTexture, UINT Level, D3DLOCKED_RECT *pLockedRect, const RECT *pRect,
                      uint32_t Flags) override;
     HRESULT UnlockRect(IDirect3DCubeTexture9 *pCubeTexture, D3DCUBEMAP_FACES FaceType, UINT Level) override;
     HRESULT UnlockRect(IDirect3DTexture9 *pTexture, UINT Level) override;
     HRESULT GetSurfaceLevel(IDirect3DTexture9 *ppTexture, UINT Level, IDirect3DSurface9 **ppSurfaceLevel) override;
-    HRESULT UpdateSurface(IDirect3DSurface9 *pSourceSurface, CONST RECT *pSourceRectsArray, UINT cRects,
-                          IDirect3DSurface9 *pDestinationSurface, CONST POINT *pDestPointsArray) override;
+    HRESULT UpdateSurface(IDirect3DSurface9 *pSourceSurface, const RECT *pSourceRectsArray, UINT cRects,
+                          IDirect3DSurface9 *pDestinationSurface, const POINT *pDestPointsArray) override;
     HRESULT StretchRect(IDirect3DSurface9 *pSourceSurface, const RECT *pSourceRect, IDirect3DSurface9 *pDestSurface,
                         const RECT *pDestRect, D3DTEXTUREFILTERTYPE Filter) override;
     HRESULT GetRenderTargetData(IDirect3DSurface9 *pRenderTarget, IDirect3DSurface9 *pDestSurface) override;
 
     // D3D Pixel/Vertex Shaders Section
-    HRESULT CreateVertexDeclaration(CONST D3DVERTEXELEMENT9 *pVertexElements,
+    HRESULT CreateVertexDeclaration(const D3DVERTEXELEMENT9 *pVertexElements,
                                     IDirect3DVertexDeclaration9 **ppDecl) override;
     HRESULT SetVertexDeclaration(IDirect3DVertexDeclaration9 *pDecl) override;
-    HRESULT CreatePixelShader(CONST uint32_t *pFunction, IDirect3DPixelShader9 **ppShader) override;
-    HRESULT CreateVertexShader(CONST uint32_t *pFunction, IDirect3DVertexShader9 **ppShader) override;
+    HRESULT CreatePixelShader(const uint32_t *pFunction, IDirect3DPixelShader9 **ppShader) override;
+    HRESULT CreateVertexShader(const uint32_t *pFunction, IDirect3DVertexShader9 **ppShader) override;
     HRESULT DeletePixelShader(IDirect3DPixelShader9 *pShader) override;
     HRESULT DeleteVertexShader(IDirect3DVertexShader9 *pShader) override;
     HRESULT SetVertexShader(IDirect3DVertexShader9 *pShader) override;
     HRESULT SetPixelShader(IDirect3DPixelShader9 *pShader) override;
-    /*virtual HRESULT SetFVFConstant(DWORD Register, CONST void* pConstantData, DWORD  ConstantCount );*/
-    HRESULT SetVertexShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4iCount) override;
-    HRESULT SetPixelShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4iCount) override;
+    /*virtual HRESULT SetFVFConstant(DWORD Register, const void* pConstantData, DWORD  ConstantCount );*/
+    HRESULT SetVertexShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4iCount) override;
+    HRESULT SetPixelShaderConstantF(UINT StartRegister, const float *pConstantData, UINT Vector4iCount) override;
     HRESULT SetFVF(uint32_t handle) override;
     HRESULT GetVertexShader(IDirect3DVertexShader9 **ppShader) override;
     HRESULT GetPixelShader(IDirect3DPixelShader9 **ppShader) override;
@@ -316,7 +316,7 @@ class DX9RENDER : public VDX9RENDER
     // D3D Render Target/Begin/End/Clear
     HRESULT GetRenderTarget(IDirect3DSurface9 **ppRenderTarget) override;
     HRESULT SetRenderTarget(IDirect3DSurface9 *pRenderTarget, IDirect3DSurface9 *pNewZStencil) override;
-    HRESULT Clear(uint32_t Count, CONST D3DRECT *pRects, uint32_t Flags, D3DCOLOR Color, float Z,
+    HRESULT Clear(uint32_t Count, const D3DRECT *pRects, uint32_t Flags, D3DCOLOR Color, float Z,
                   uint32_t Stencil) override;
     HRESULT BeginScene() override;
     HRESULT EndScene() override;

--- a/src/libs/renderer/src/storm_d3dx9.cpp
+++ b/src/libs/renderer/src/storm_d3dx9.cpp
@@ -2,6 +2,8 @@
 
 #include "platform/d3dx9.hpp"
 
+#include <cstdio>
+#include <cstring> // for memcpy
 #include <algorithm>
 
 #define WARN(...) fprintf(stdout, __VA_ARGS__)

--- a/src/libs/util/include/utf8.h
+++ b/src/libs/util/include/utf8.h
@@ -4,7 +4,9 @@
 #include <cstring>
 #include <string>
 
+#ifdef _WIN32 // for WideCharToMultiByte / MultiByteToWideChar
 #include <windows.h>
+#endif
 
 namespace utf8
 {

--- a/src/libs/xinterface/src/editor/editor_defines.cpp
+++ b/src/libs/xinterface/src/editor/editor_defines.cpp
@@ -1,5 +1,7 @@
 #include "editor_defines.h"
 
+#include <cstdint>
+
 void GIEditorObject::LinkEvent(GIEditorEventHandler *pEventHandler, const GIEditorEvent &pEventFunction)
 {
     pEventHandler->AddEventFunction(this, pEventFunction);

--- a/src/libs/xinterface/src/storm/xinterface/options_parser.cpp
+++ b/src/libs/xinterface/src/storm/xinterface/options_parser.cpp
@@ -1,5 +1,7 @@
 #include "options_parser.hpp"
 
+#include <algorithm>
+
 namespace storm
 {
 

--- a/src/libs/xinterface/src/string_service.h
+++ b/src/libs/xinterface/src/string_service.h
@@ -15,7 +15,7 @@ class VSTRSERVICE : public SERVICE
     virtual void SetLanguage(const char *sLanguage) = 0;
     virtual char *GetLanguage() = 0;
 
-    virtual char *GetString(const char *stringName, char *sBuffer = nullptr, size_t bufferSize = 0) = 0;
+    virtual char *GetString(const char *stringName, char *sBuffer = nullptr, std::size_t bufferSize = 0) = 0;
     virtual int32_t GetStringNum(const char *stringName) = 0;
     virtual char *GetString(int32_t strNum) = 0;
     virtual char *GetStringName(int32_t strNum) = 0;

--- a/src/libs/xinterface/src/string_service/str_service.h
+++ b/src/libs/xinterface/src/string_service/str_service.h
@@ -33,7 +33,7 @@ class STRSERVICE : public VSTRSERVICE
     void SetLanguage(const char *sLanguage) override;
     char *GetLanguage() override;
 
-    char *GetString(const char *stringName, char *sBuffer = nullptr, size_t bufferSize = 0) override;
+    char *GetString(const char *stringName, char *sBuffer = nullptr, std::size_t bufferSize = 0) override;
     int32_t GetStringNum(const char *stringName) override;
     char *GetString(int32_t strNum) override;
     char *GetStringName(int32_t strNum) override;


### PR DESCRIPTION
Replace Windows only types: VOID, CONST.
Fix few includes and types for clang-14.