### PR TITLE
Enable setting _DEBUG flag on Linux build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,9 @@ else()
     # Always generate debug information
     add_compile_options(-g)
     add_link_options(-g)
+
+    # Add _DEBUG flag
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
 endif()
 
 # this is crucial to include libs first


### PR DESCRIPTION
This PR enables setting the _DEBUG macro in CMake when building on Linux. The problem it solves is described in #451 