### PR TITLE
Expose worldmap label position back as attributes

### DIFF
--- a/src/libs/worldmap/src/wdm_islands.cpp
+++ b/src/libs/worldmap/src/wdm_islands.cpp
@@ -462,6 +462,12 @@ void WdmIslands::SetIslandsData(ATTRIBUTES *apnt, bool isChange)
             labels[index].textX = 0.0f;
             labels[index].textY = 0.0f;
         }
+
+        // Store locator position as label attribute
+        auto* position_attr = a->VerifyAttributeClass("position");
+        position_attr->SetAttributeUseFloat("x", pos.x);
+        position_attr->SetAttributeUseFloat("y", pos.y);
+        position_attr->SetAttributeUseFloat("z", pos.z);
     }
 }
 


### PR DESCRIPTION
Makes the worldmap write all label positions it reads from the model file as attributes on the entity.

Enables me to store the locations of islands an towns in the worldmap model without having to duplicate all the data in the code.