### PR TITLE
[sea_foam] change vbuffer pool

### DIFF
--- a/src/libs/renderer/include/dx9render.h
+++ b/src/libs/renderer/include/dx9render.h
@@ -279,7 +279,8 @@ class VDX9RENDER : public SERVICE
     virtual void ReleaseVideoTexture(CVideoTexture *pVTexture) = 0;
 
     // DX9Render: Vertex/Index Buffers Section
-    virtual int32_t CreateVertexBuffer(int32_t type, size_t nverts, uint32_t usage) = 0;
+    virtual int32_t CreateVertexBuffer(int32_t type, size_t nverts, uint32_t usage,
+                                       uint32_t dwPool = D3DPOOL_DEFAULT) = 0;
     virtual int32_t CreateIndexBuffer(size_t ntrgs, uint32_t dwUsage = D3DUSAGE_WRITEONLY) = 0;
 
     virtual IDirect3DVertexBuffer9 *GetVertexBuffer(int32_t id) = 0;

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -2179,7 +2179,7 @@ bool DX9RENDER::GetLight(uint32_t dwIndex, D3DLIGHT9 *pLight)
 
 //################################################################################
 
-int32_t DX9RENDER::CreateVertexBuffer(int32_t type, size_t size, uint32_t dwUsage)
+int32_t DX9RENDER::CreateVertexBuffer(int32_t type, size_t size, uint32_t dwUsage, uint32_t dwPool)
 {
     if (size <= 0)
         return -1; // fix
@@ -2192,7 +2192,8 @@ int32_t DX9RENDER::CreateVertexBuffer(int32_t type, size_t size, uint32_t dwUsag
     if (b == MAX_BUFFERS)
         return -1;
 
-    if (CHECKD3DERR(d3d9->CreateVertexBuffer(size, dwUsage, type, D3DPOOL_DEFAULT, &VertexBuffers[b].buff, NULL)))
+    if (CHECKD3DERR(d3d9->CreateVertexBuffer(size, dwUsage, type, static_cast<D3DPOOL>(dwPool),
+                                             &VertexBuffers[b].buff, NULL)))
         return -1;
 
     VertexBuffers[b].type = type;

--- a/src/libs/renderer/src/s_device.h
+++ b/src/libs/renderer/src/s_device.h
@@ -211,8 +211,8 @@ class DX9RENDER : public VDX9RENDER
     void ReleaseVideoTexture(CVideoTexture *pVTexture) override;
 
     // DX9Render: Vertex/Index Buffers Section
-    int32_t CreateVertexBuffer(int32_t type, size_t nverts, uint32_t usage) override;
-    int32_t CreateIndexBuffer(size_t ntrgs, uint32_t dwUsage = D3DUSAGE_WRITEONLY) override;
+    int32_t CreateVertexBuffer(int32_t type, size_t nverts, uint32_t usage, uint32_t dwPool) override;
+    int32_t CreateIndexBuffer(size_t ntrgs, uint32_t dwUsage) override;
 
     IDirect3DVertexBuffer9 *GetVertexBuffer(int32_t id) override;
     int32_t GetVertexBufferFVF(int32_t id) override;

--- a/src/libs/sea_foam/src/t_carcass.cpp
+++ b/src/libs/sea_foam/src/t_carcass.cpp
@@ -20,7 +20,7 @@ TCarcass::TCarcass(int _levelsCount, int _measurePointsCount, VDX9RENDER *_rende
     uSpeed = 15e-5f;
     iBuffer = renderer->CreateIndexBuffer(3 * 2 * (MEASURE_POINTS - 1) * (TRACE_STEPS_Z - 1) * sizeof(uint16_t));
     vBuffer = renderer->CreateVertexBuffer(
-        CARCASS_VERTEX_FORMAT, MEASURE_POINTS * (TRACE_STEPS_Z + 1) * sizeof(tCarcassVertex), D3DUSAGE_WRITEONLY);
+        CARCASS_VERTEX_FORMAT, MEASURE_POINTS * (TRACE_STEPS_Z + 1) * sizeof(tCarcassVertex), 0, D3DPOOL_MANAGED);
 }
 
 //--------------------------------------------------------------------


### PR DESCRIPTION
GPU write-only pool for dynamic vertex buffer has a significant negative impact on performance.
This is essentially a more simple and idiomatic way of doing what #436 does