### PR TITLE
Fix LegacyDialog crash when setting headmodel to the same value twice

### DIFF
--- a/src/libs/dialog/src/legacy_dialog.cpp
+++ b/src/libs/dialog/src/legacy_dialog.cpp
@@ -438,7 +438,7 @@ void LegacyDialog::DrawBackground(size_t start, size_t count)
 
 void LegacyDialog::SetAction(std::string action)
 {
-    if (!headModel_)
+    if (headModel_ == invalid_entity)
         return;
 
     std::string preparedAction = action;
@@ -465,13 +465,18 @@ void LegacyDialog::SetAction(std::string action)
 
 void LegacyDialog::UpdateHeadModel(const std::string &headModelPath)
 {
-    core.EraseEntity(headModel_);
-
     const std::string newHeadModelPath = fmt::format("Heads/{}", headModelPath);
 
     if (headModelPath_ != newHeadModelPath)
     {
         headModelPath_ = newHeadModelPath;
+
+        if (headModel_ != invalid_entity)
+        {
+            core.EraseEntity(headModel_);
+            headModel_ = invalid_entity;
+        }
+
         headModel_ = core.CreateEntity("MODELR");
         auto gs = static_cast<VGEOMETRY *>(core.GetService("geometry"));
         gs->SetTexturePath("characters\\");
@@ -505,7 +510,7 @@ void LegacyDialog::UpdateHeadModel(const std::string &headModelPath)
 
 void LegacyDialog::DrawHeadModel(uint32_t deltaTime)
 {
-    if (headModel_)
+    if (headModel_ != invalid_entity)
     {
         D3DVIEWPORT9 viewport;
         RenderService->GetViewport(&viewport);

--- a/src/libs/dialog/src/legacy_dialog.hpp
+++ b/src/libs/dialog/src/legacy_dialog.hpp
@@ -97,7 +97,7 @@ class LegacyDialog final : public Entity
 
     int32_t fadeTime_{};
 
-    entid_t headModel_;
+    entid_t headModel_{invalid_entity};
 
     std::string mood_ = "normal";
 


### PR DESCRIPTION
When setting `headModel` to the same value twice, the old entity was being deleted but the creation of a new one was skipped.

Fixes https://github.com/PiratesAhoy/new-horizons/issues/20