### PR TITLE
Validate collision data during load on debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(StormSetup)
 
 option(STORM_ENABLE_CRASH_REPORTS "Enable automatic crash reports" OFF)
 option(STORM_ENABLE_STEAM "Enable Steam integration" OFF)
+option(STORM_ENABLE_SAFE_MODE "Enable additional runtime checks" OFF)
 
 ### Set up output paths
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,10 @@ if(STORM_WATERMARK_FILE)
   add_definitions(-DSTORM_WATERMARK_FILE="${STORM_WATERMARK_FILE}")
 endif()
 
+if(STORM_ENABLE_SAFE_MODE)
+  add_definitions(-DSTORM_ENABLE_SAFE_MODE=1)
+endif()
+
 if (MSVC)
     # Ignore warnings about missing pdb
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ignore:4099")

--- a/src/libs/blot/src/blots.cpp
+++ b/src/libs/blot/src/blots.cpp
@@ -283,7 +283,7 @@ void Blots::SetNodesCollision(NODE *n, bool isSet)
         n->flags |= n->flags >> 24;
         n->flags &= 0x00ffffff;
     }
-    for (int32_t i = 0; i < n->nnext; i++)
+    for (int32_t i = 0; i < n->next.size(); i++)
         SetNodesCollision(n->next[i], isSet);
 }
 

--- a/src/libs/core/include/storm/config.hpp
+++ b/src/libs/core/include/storm/config.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace storm {
+
+#ifdef _DEBUG
+constexpr bool kIsDebug = true;
+#else
+constexpr bool kIsDebug = false;
+#endif
+
+#ifdef STORM_ENABLE_SAFE_MODE
+constexpr bool kIsSafeMode = true;
+#else
+constexpr bool kIsSafeMode = false;
+#endif
+
+constexpr bool kValidateCollisionData = kIsSafeMode || kIsDebug;
+
+}

--- a/src/libs/geometry/src/collide.cpp
+++ b/src/libs/geometry/src/collide.cpp
@@ -33,7 +33,7 @@ float GEOM::Trace(VERTEX &start, VERTEX &finish)
     diss = 0.0;
     dise = 1.0;
     dirvec = dst - src;
-    node = sroot;
+    node = sroot.data();
     stack = _stack - 1;
 
 rec_loop:;
@@ -129,9 +129,9 @@ rec_return:;
         const auto face = (static_cast<int32_t>(*(pface + 2)) << 16) | (static_cast<int32_t>(*(pface + 1)) << 8) |
                           (static_cast<int32_t>(*(pface + 0)) << 0);
         int32_t vindex[3];
-        vindex[0] = (btrg[face].vindex[0][0] << 0) | (btrg[face].vindex[0][1] << 8) | (btrg[face].vindex[0][2] << 16);
-        vindex[1] = (btrg[face].vindex[1][0] << 0) | (btrg[face].vindex[1][1] << 8) | (btrg[face].vindex[1][2] << 16);
-        vindex[2] = (btrg[face].vindex[2][0] << 0) | (btrg[face].vindex[2][1] << 8) | (btrg[face].vindex[2][2] << 16);
+        vindex[0] = btrg[face].getIndex(0);
+        vindex[1] = btrg[face].getIndex(1);
+        vindex[2] = btrg[face].getIndex(2);
 
         // Tomas Moller and Ben Trumbore algorithm
 
@@ -296,7 +296,7 @@ bool GEOM::Clip(const PLANE *planes, int32_t nplanes, const VERTEX &center, floa
         attempt++;
     }
 
-    BSP_NODE *node = sroot;
+    BSP_NODE *node = sroot.data();
     int32_t rec_level = -1;
 
 rec_loop:;

--- a/src/libs/geometry/src/geom.h
+++ b/src/libs/geometry/src/geom.h
@@ -12,6 +12,8 @@ Import library class
 #include "rdf.h"
 #include "geos.h"
 
+#include <vector>
+
 #define EPSILON 4e-7
 
 struct SAVAGE
@@ -23,9 +25,9 @@ struct SAVAGE
 class GEOM : public GEOS
 {
     static SAVAGE _stack[256];
-    CVECTOR *vrt;
-    RDF_BSPTRIANGLE *btrg;
-    BSP_NODE *sroot;
+    std::vector<CVECTOR> vrt{};
+    std::vector<RDF_BSPTRIANGLE> btrg{};
+    std::vector<BSP_NODE> sroot{};
 
     CVECTOR res_norm;
     float res_pldist;
@@ -43,18 +45,18 @@ class GEOM : public GEOS
     GEOM_SERVICE &srv;
 
     RDF_HEAD rhead;
-    char *globname;
-    int32_t *names;
-    int32_t *tname;
-    int32_t *tlookup;
-    MATERIAL *material;
-    LIGHT *light;
-    LABEL *label;
-    OBJECT *object;
+    char *globname = nullptr;
+    int32_t *names = nullptr;
+    int32_t *tname = nullptr;
+    int32_t *tlookup = nullptr;
+    MATERIAL *material = nullptr;
+    LIGHT *light = nullptr;
+    LABEL *label = nullptr;
+    OBJECT *object = nullptr;
     int32_t idx_buff;
-    VERTEX_BUFFER *vbuff;
+    VERTEX_BUFFER *vbuff = nullptr;
 
-    int32_t *atriangles;
+    int32_t *atriangles = nullptr;
     int32_t traceid;
     DVECTOR src, dst;
 

--- a/src/libs/geometry/src/geom_static.cpp
+++ b/src/libs/geometry/src/geom_static.cpp
@@ -12,7 +12,7 @@ Import library main file
 
 #include <cstdint>
 #include <cstring>
-#include <format>
+#include <fmt/format.h>
 #include <vector>
 
 #include "../../util/include/string_compare.hpp"
@@ -210,7 +210,7 @@ GEOM::GEOM(const char *fname, const char *lightname, GEOM_SERVICE &_srv, int32_t
             });
             if (!valid)
             {
-                throw std::runtime_error(std::format("Detected invalid collision data while loading file '{}'", fname));
+                throw std::runtime_error(fmt::format("Detected invalid collision data while loading file '{}'", fname));
             }
         }
     }

--- a/src/libs/geometry/src/rdf.h
+++ b/src/libs/geometry/src/rdf.h
@@ -271,6 +271,10 @@ struct RDF_BSPHEAD
 struct RDF_BSPTRIANGLE
 {
     unsigned char vindex[3][3];
+
+    constexpr int32_t getIndex(size_t i) const {
+        return (vindex[i][0] << 0) | (vindex[i][1] << 8) | (vindex[i][2] << 16);
+    }
 };
 
 #define RDF_BSPVERTEX CVECTOR

--- a/src/libs/mast/src/mast.cpp
+++ b/src/libs/mast/src/mast.cpp
@@ -395,7 +395,7 @@ void MAST::Mount(entid_t modelEI, entid_t shipEI, NODE *mastNodePointer)
         }
 
         // set the left and right points of the yard
-        for (i = 0; i < mastNodePointer->nnext; i++)
+        for (i = 0; i < mastNodePointer->next.size(); i++)
             if (!strncmp(mastNodePointer->next[i]->GetName(), "rey", 3))
             {
                 mastNodePointer->next[i]->geo->GetInfo(gi);
@@ -409,7 +409,7 @@ void MAST::Mount(entid_t modelEI, entid_t shipEI, NODE *mastNodePointer)
                 }
                 break;
             }
-        if (i == mastNodePointer->nnext)
+        if (i == mastNodePointer->next.size())
             mm.brey = mm.erey = CVECTOR(0.f, 0.f, 0.f);
         else
         {

--- a/src/libs/model/include/model.h
+++ b/src/libs/model/include/model.h
@@ -28,8 +28,7 @@ class NODE
     GEOS *geo;
     GEOS::MATERIAL_FUNC geoMaterialFunc;
     // children
-    int32_t nnext;
-    NODE **next;
+    std::vector<NODE *> next;
     // 0 for root
     NODE *parent;
 

--- a/src/libs/model/src/model.cpp
+++ b/src/libs/model/src/model.cpp
@@ -158,7 +158,7 @@ void SetChildrenTechnique(NODE *_root, const char *_name)
     if (!_root || !_name)
         return;
     _root->SetTechnique(_name);
-    for (int i = 0; i < _root->nnext; i++)
+    for (int i = 0; i < _root->next.size(); i++)
         SetChildrenTechnique(_root->next[i], _name);
 }
 

--- a/src/libs/model/src/node.cpp
+++ b/src/libs/model/src/node.cpp
@@ -276,12 +276,7 @@ NODER::~NODER()
 #endif
 
     delete geo;
-    for (NODE *node : next) {
-        if (node != nullptr) {
-            delete node;
-        }
-    }
-    next.clear();
+    std::destroy(next.begin(), next.end());
 }
 
 void NODER::ReleaseGeometry()

--- a/src/libs/model/src/node.cpp
+++ b/src/libs/model/src/node.cpp
@@ -86,7 +86,7 @@ bool NODER::Clip()
     }
 
     if (flags & CLIP_ENABLE_TREE)
-        for (int32_t l = 0; l < nnext; l++)
+        for (int32_t l = 0; l < next.size(); l++)
             if (next[l] != nullptr && static_cast<NODER *>(next[l])->Clip() == true)
                 retval = true;
     return retval;
@@ -102,7 +102,7 @@ float NODER::Update(CMatrix &mtx, CVECTOR &cnt)
     center = geo_center;
     radius = geo_radius;
 
-    for (int32_t l = 0; l < nnext; l++)
+    for (int32_t l = 0; l < next.size(); l++)
         if (next[l] != nullptr)
         {
             CVECTOR cnt; // TODO: huh? ~!~
@@ -134,7 +134,7 @@ float NODER::Trace(const CVECTOR &src, const CVECTOR &dst)
     auto best_dist = 2.0f;
 
     if (flags & TRACE_ENABLE_TREE)
-        for (int32_t n = 0; n < nnext; n++)
+        for (int32_t n = 0; n < next.size(); n++)
         {
             if (next[n] == nullptr)
                 continue;
@@ -170,8 +170,6 @@ NODER::NODER()
     sphere = 0;
 #endif
     geo = nullptr;
-    nnext = 0;
-    next = nullptr;
     parent = nullptr;
 
     max_view_dist = 0.f;
@@ -225,16 +223,14 @@ bool NODER::Init(const char *lightPath, const char *pname, const char *oname, co
         strcpy_s(name, pname);
     // calculate number of labels
     const auto idGeo = geo->FindName("geometry");
-    nnext = 0;
+    int32_t node_count = 0;
     int32_t sti = -1;
     while ((sti = geo->FindLabelG(sti + 1, idGeo)) > -1)
-        nnext++;
+        node_count++;
 
-    if (nnext > 0)
+    if (node_count > 0)
     {
-        next = static_cast<NODE **>(malloc(sizeof(NODE *) * nnext));
-        for (int32_t ii = 0; ii < nnext; ii++)
-            next[ii] = nullptr;
+        next = std::vector<NODE *>(node_count, nullptr);
         int32_t sti = -1;
         int32_t l = 0;
         while ((sti = geo->FindLabelG(sti + 1, idGeo)) > -1)
@@ -280,11 +276,12 @@ NODER::~NODER()
 #endif
 
     delete geo;
-    for (int32_t l = 0; l < nnext; l++)
-        if (next[l] != nullptr)
-            delete next[l];
-    if (nnext > 0)
-        free(next);
+    for (NODE *node : next) {
+        if (node != nullptr) {
+            delete node;
+        }
+    }
+    next.clear();
 }
 
 void NODER::ReleaseGeometry()
@@ -294,7 +291,7 @@ void NODER::ReleaseGeometry()
     delete geo;
     geo = nullptr;
     isReleased = true;
-    for (int32_t i = 0; i < nnext; i++)
+    for (int32_t i = 0; i < next.size(); i++)
     {
         if (!next[i])
             continue;
@@ -319,7 +316,7 @@ void NODER::RestoreGeometry()
         throw std::runtime_error(fmt::format("Cannot restore geometry {}", sys_modelName_full));
 
     isReleased = false;
-    for (int32_t i = 0; i < nnext; i++)
+    for (int32_t i = 0; i < next.size(); i++)
     {
         if (!next[i])
             continue;
@@ -438,7 +435,7 @@ void NODER::Draw()
 
     // draw all children
     if (flags & VISIBLE_TREE)
-        for (int32_t l = 0; l < nnext; l++)
+        for (int32_t l = 0; l < next.size(); l++)
             if (next[l] != nullptr)
                 static_cast<NODER *>(next[l])->Draw();
 }
@@ -450,7 +447,7 @@ NODER *NODER::FindNode(const char *cNodeName)
 {
     if (storm::iEquals(cNodeName, name))
         return this;
-    for (int32_t i = 0; i < nnext; i++)
+    for (int32_t i = 0; i < next.size(); i++)
     {
         if (!next[i])
             continue;
@@ -475,7 +472,7 @@ NODER *NODER::GetNode(int32_t n)
         return this;
     }
     node++;
-    for (int32_t l = 0; l < nnext; l++)
+    for (int32_t l = 0; l < next.size(); l++)
     {
         if (next[l] == nullptr)
             continue;
@@ -530,7 +527,7 @@ entid_t NODER::Unlink2Model()
         // get parent matrix
         mdl->mtx = parent->glob_mtx;
 
-        for (int32_t l = 0; l < parent->nnext; l++)
+        for (int32_t l = 0; l < parent->next.size(); l++)
             if (parent->next[l] == this)
             {
                 parent->next[l] = nullptr;
@@ -552,14 +549,12 @@ void NODER::Link(entid_t id, bool transform)
         return;
 
     // increment number of children
-    nnext++;
-    next = static_cast<NODE **>(realloc(next, sizeof(NODE *) * nnext));
-    next[nnext - 1] = mdl->root;
+    next.push_back(mdl->root);
 
     // modify loc_mtx of node
     if (transform)
     {
-        CMatrix glob_parent = next[nnext - 1]->glob_mtx;
+        CMatrix glob_parent = next.back()->glob_mtx;
         // glob_parent.Transposition();
         // next[nnext-1]->loc_mtx = mdl->mtx * glob_parent;
     }
@@ -589,7 +584,7 @@ const char *NODER::GetTechnique()
 void NODER::SetMaxViewDist(float fDist)
 {
     max_view_dist = fDist;
-    for (int32_t n = 0; n < nnext; n++)
+    for (int32_t n = 0; n < next.size(); n++)
         if (next[n])
             static_cast<NODER *>(next[n])->SetMaxViewDist(fDist);
 }


### PR DESCRIPTION
I was debugging some crashes that were caused by invalid collision data.

I've added some code that will do some validation on the collision data when loading models. This can be toggled using a `VALIDATE_COLLISION_DATA` variable. Currently configured to only run this in debug builds.

Hopefully this will make debugging future collision issues easier.