### PR TITLE
Improve CMake files for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug
 
 set(STORM_WATERMARK_FILE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/watermark.hpp CACHE FILEPATH "Include file containing build revision, etc." FORCE)
 
+if (NOT WIN32)
+    include(linux)
+endif()
+
 ### Set up third-party dependencies
 set(ENV{CONAN_REVISIONS_ENABLED} 1)
 conan_add_remote(NAME bincrafters
@@ -36,30 +40,6 @@ conan_cmake_run(CONANFILE conanfile.py
         crash_reports=${STORM_ENABLE_CRASH_REPORTS}
         steam=${STORM_ENABLE_STEAM}
 )
-
-if (NOT WIN32)
-    message("Using DXVK-native for D3D9 API")
-
-    include(ExternalProject)
-    ExternalProject_Add(dxvk-native
-        GIT_REPOSITORY    https://github.com/Joshua-Ashton/dxvk-native
-        GIT_TAG           a2dc99c407340432d4ba5bfa29efa685c27942ea
-        GIT_SHALLOW       ON
-        BUILD_ALWAYS      OFF
-        CONFIGURE_HANDLED_BY_BUILD ON
-        CONFIGURE_COMMAND meson setup ../dxvk-native --buildtype=release -Denable_d3d11=false -Denable_d3d10=false -Denable_dxgi=false
-        BUILD_COMMAND     ninja
-        INSTALL_COMMAND   ""
-    )
-    ExternalProject_Get_property(dxvk-native SOURCE_DIR BINARY_DIR)
-    set(DXVK_NATIVE_INCLUDE_DIRS
-        "${SOURCE_DIR}/include/native/directx"
-        "${SOURCE_DIR}/include/native/windows"
-    )
-    set(NATIVE_D3D9_LIBS ${BINARY_DIR}/src/d3d9/libdxvk_d3d9.so)
-    include_directories("${DXVK_NATIVE_INCLUDE_DIRS}")
-    add_custom_target(dependencies ALL DEPENDS dxvk-native)
-endif()
 
 ### Define library ALIASes for use without CONAN_PKG:: prefix
 foreach (conan_target ${CONAN_TARGETS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if (NOT WIN32)
         GIT_SHALLOW       ON
         BUILD_ALWAYS      OFF
         CONFIGURE_HANDLED_BY_BUILD ON
-        CONFIGURE_COMMAND meson ../dxvk-native
+        CONFIGURE_COMMAND meson setup ../dxvk-native --buildtype=release -Denable_d3d11=false -Denable_d3d10=false -Denable_dxgi=false
         BUILD_COMMAND     ninja
         INSTALL_COMMAND   ""
     )
@@ -56,9 +56,9 @@ if (NOT WIN32)
         "${SOURCE_DIR}/include/native/directx"
         "${SOURCE_DIR}/include/native/windows"
     )
-    set(DXVK_NATIVE_D3D9_LIB ${BINARY_DIR}/src/d3d9/libdxvk_d3d9.so)
+    set(NATIVE_D3D9_LIBS ${BINARY_DIR}/src/d3d9/libdxvk_d3d9.so)
     include_directories("${DXVK_NATIVE_INCLUDE_DIRS}")
-    ADD_CUSTOM_TARGET(dependencies ALL DEPENDS dxvk-native)
+    add_custom_target(dependencies ALL DEPENDS dxvk-native)
 endif()
 
 ### Define library ALIASes for use without CONAN_PKG:: prefix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ include(StormSetup)
 option(STORM_ENABLE_CRASH_REPORTS "Enable automatic crash reports" OFF)
 option(STORM_ENABLE_STEAM "Enable Steam integration" OFF)
 option(STORM_ENABLE_SAFE_MODE "Enable additional runtime checks" OFF)
+option(STORM_USE_CONAN_SDL "Use sdl from conan" ON)
 
 ### Set up output paths
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -16,7 +17,9 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug
 
 set(STORM_WATERMARK_FILE ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/watermark.hpp CACHE FILEPATH "Include file containing build revision, etc." FORCE)
 
-if (NOT WIN32)
+if (WIN32)
+    set(SDL2_LIBRARIES "sdl")
+else()
     include(linux)
 endif()
 
@@ -30,7 +33,7 @@ conan_add_remote(NAME storm
     URL https://storm.jfrog.io/artifactory/api/conan/conan-remote
     VERIFY_SSL True
 )
-normalize_booleans(STORM_ENABLE_CRASH_REPORTS STORM_ENABLE_STEAM)
+normalize_booleans(STORM_ENABLE_CRASH_REPORTS STORM_ENABLE_STEAM STORM_USE_CONAN_SDL)
 conan_cmake_run(CONANFILE conanfile.py
     BASIC_SETUP CMAKE_TARGETS
     BUILD missing
@@ -39,6 +42,7 @@ conan_cmake_run(CONANFILE conanfile.py
         watermark_file=${STORM_WATERMARK_FILE}
         crash_reports=${STORM_ENABLE_CRASH_REPORTS}
         steam=${STORM_ENABLE_STEAM}
+        conan_sdl=${STORM_USE_CONAN_SDL}
 )
 
 ### Define library ALIASes for use without CONAN_PKG:: prefix

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -1,0 +1,21 @@
+message("Using DXVK-native for D3D9 API")
+
+include(ExternalProject)
+ExternalProject_Add(dxvk-native
+    GIT_REPOSITORY    https://github.com/Joshua-Ashton/dxvk-native
+    GIT_TAG           a2dc99c407340432d4ba5bfa29efa685c27942ea
+    GIT_SHALLOW       ON
+    BUILD_ALWAYS      OFF
+    CONFIGURE_HANDLED_BY_BUILD ON
+    CONFIGURE_COMMAND meson setup ../dxvk-native --buildtype=release -Denable_d3d11=false -Denable_d3d10=false -Denable_dxgi=false
+    BUILD_COMMAND     ninja
+    INSTALL_COMMAND   ""
+)
+ExternalProject_Get_property(dxvk-native SOURCE_DIR BINARY_DIR)
+set(DXVK_NATIVE_INCLUDE_DIRS
+    "${SOURCE_DIR}/include/native/directx"
+    "${SOURCE_DIR}/include/native/windows"
+)
+set(NATIVE_D3D9_LIBS ${BINARY_DIR}/src/d3d9/libdxvk_d3d9.so)
+include_directories("${DXVK_NATIVE_INCLUDE_DIRS}")
+add_custom_target(dependencies ALL DEPENDS dxvk-native)

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -1,3 +1,12 @@
+if(STORM_USE_CONAN_SDL)
+    set(SDL2_LIBRARIES "sdl")
+else()
+    find_package(SDL2 REQUIRED)
+    message(STATUS "SDL2_LIBRARIES="${SDL2_LIBRARIES})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${SDL2_INCLUDE_DIRS} -fsigned-char")
+    message(STATUS "CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS})
+endif()
+
 message("Using DXVK-native for D3D9 API")
 
 include(ExternalProject)

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,12 +11,13 @@ class StormEngine(ConanFile):
         "output_directory": "ANY",
         "watermark_file": "ANY",
         "crash_reports": [True, False],
-        "steam": [True, False]
+        "steam": [True, False],
+        "conan_sdl": [True, False]
     }
 
     # dependencies used in deploy binaries
     # conan-center
-    requires = ["zlib/1.2.11", "spdlog/1.9.2", "fast_float/3.4.0", "sdl/2.0.18", "mimalloc/2.0.3", "sentry-native/0.5.0",
+    requires = ["zlib/1.2.11", "spdlog/1.9.2", "fast_float/3.4.0", "mimalloc/2.0.3", "sentry-native/0.5.0",
     # storm.jfrog.io
     "directx/9.0@storm/prebuilt", "fmod/2.02.05@storm/prebuilt"]
     # aux dependencies (e.g. for tests)
@@ -34,6 +35,8 @@ class StormEngine(ConanFile):
             self.options["libsndfile"].with_mpeg= False #fix for 0a12560440ac9f760670829a1cde44b787f587ad/src/src/libmpg123/mpg123lib_intern.h:346: undefined reference to `__pow_finite'
         if self.options.steam:
             self.requires("steamworks/1.5.1@storm/prebuilt")
+        if self.options.conan_sdl:
+            self.requires("sdl/2.0.18")
 
     generators = "cmake_multi"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,9 +50,8 @@ else()
     add_compile_options(-v)
     add_link_options(-v)
 
-    # Always generate debug information
-    add_compile_options(-g)
-    add_link_options(-g)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -g")
 
     # Add _DEBUG flag
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")

--- a/src/apps/engine/CMakeLists.txt
+++ b/src/apps/engine/CMakeLists.txt
@@ -32,7 +32,7 @@ STORM_SETUP(
     # external
     mimalloc
     sentry-native
-    sdl
+    ${SDL2_LIBRARIES}
     zlib
 
     # system

--- a/src/libs/core/CMakeLists.txt
+++ b/src/libs/core/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME core
     TYPE library
-    DEPENDENCIES diagnostics math shared_headers steam_api fast_float sdl window
+    DEPENDENCIES diagnostics math shared_headers steam_api fast_float ${SDL2_LIBRARIES} window
 )

--- a/src/libs/input/CMakeLists.txt
+++ b/src/libs/input/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME input
     TYPE library
-    DEPENDENCIES sdl util
+    DEPENDENCIES ${SDL2_LIBRARIES} util
 )

--- a/src/libs/renderer/CMakeLists.txt
+++ b/src/libs/renderer/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (WIN32)
 set(SYSTEM_DEPS "legacy_stdio_definitions")
 else()
-set(SYSTEM_DEPS "${DXVK_NATIVE_D3D9_LIB}")
+set(SYSTEM_DEPS "${NATIVE_D3D9_LIBS}")
 endif()
 
 STORM_SETUP(

--- a/src/libs/window/CMakeLists.txt
+++ b/src/libs/window/CMakeLists.txt
@@ -1,5 +1,5 @@
 STORM_SETUP(
     TARGET_NAME window
     TYPE library
-    DEPENDENCIES sdl
+    DEPENDENCIES ${SDL2_LIBRARIES}
 )


### PR DESCRIPTION
- Build Release version of DXVK Native + only D3D9 library.
- Move Linux stuff in separate CMake file.
- Add option `STORM_USE_CONAN_SDL` (which is enabled by default): when `STORM_USE_CONAN_SDL=ON` CMake will use SDL from conan, when `STORM_USE_CONAN_SDL=ON` CMake will search and use SDL from system.
- Add `-O3` flag for Release on Linux.