### PR TITLE
Fix infinite recursion caused by var referencing itself

### DIFF
--- a/src/libs/core/src/data.cpp
+++ b/src/libs/core/src/data.cpp
@@ -2432,6 +2432,7 @@ DATA *DATA::GetVarPointer()
     if (Data_type != VAR_REFERENCE)
         return this;
     if (pReference == this) {
+        Error("ref points to itself");
         return this;
     }
     if (pReference)

--- a/src/libs/core/src/data.cpp
+++ b/src/libs/core/src/data.cpp
@@ -2431,6 +2431,9 @@ DATA *DATA::GetVarPointer()
     // if(!bRef) return this;
     if (Data_type != VAR_REFERENCE)
         return this;
+    if (pReference == this) {
+        return this;
+    }
     if (pReference)
     {
         return pReference->GetVarPointer();


### PR DESCRIPTION
Prevents the game from crashing while saving due to a stack overflow.

Problem was a variable referencing itself, possibly as the side-effect of loading an incompatible save game.