### PR TITLE
Fix invalid lexicographical_compare

### DIFF
--- a/src/libs/util/include/istring.hpp
+++ b/src/libs/util/include/istring.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+
+namespace storm
+{
+
+template <typename T> struct ichar_traits : public std::char_traits<T>
+{
+    static bool eq(T c1, T c2)
+    {
+        return std::toupper(c1) == std::toupper(c2);
+    }
+
+    static bool lt(T c1, T c2)
+    {
+        return std::toupper(c1) < std::toupper(c2);
+    }
+
+    static int compare(const T *s1, const T *s2, size_t n)
+    {
+        while (n-- != 0)
+        {
+            if (std::toupper(*s1) < std::toupper(*s2))
+                return -1;
+            if (std::toupper(*s1) > std::toupper(*s2))
+                return 1;
+            ++s1;
+            ++s2;
+        }
+        return 0;
+    }
+
+    static const T *find(const T *source, int n, const T &target)
+    {
+        const auto uppercase_target = std::toupper(target);
+        while (n-- > 0 && std::toupper(*source) != uppercase_target)
+        {
+            ++source;
+        }
+        return source;
+    }
+};
+
+using istring = std::basic_string<char, ichar_traits<char>>;
+using istring_view = std::basic_string_view<char, ichar_traits<char>>;
+
+template <class DstTraits, class CharT, class SrcTraits>
+constexpr std::basic_string_view<CharT, DstTraits> traits_cast(
+    const std::basic_string_view<CharT, SrcTraits> &src) noexcept
+{
+    return {src.data(), src.size()};
+}
+
+template <class DstTraits, class CharT, class SrcTraits>
+constexpr std::basic_string<CharT, DstTraits> traits_cast(
+    const std::basic_string<CharT, SrcTraits> &src) noexcept
+{
+    return {src.data(), src.size()};
+}
+
+} // namespace storm

--- a/src/libs/util/include/string_compare.hpp
+++ b/src/libs/util/include/string_compare.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "istring.hpp"
+
 #include <algorithm>
 #include <cctype>
 #include <string>
@@ -13,13 +15,6 @@ struct is_iequal
     template <typename T1, typename T2 = T1> bool operator()(const T1 &first, const T2 &second) const
     {
         return std::toupper(first) == std::toupper(second);
-    }
-};
-
-struct cmp_icase {
-    template <typename T1, typename T2 = T1> std::strong_ordering operator()(const T1 &first, const T2 &second) const
-    {
-        return std::toupper(first) <=> std::toupper(second);
     }
 };
 
@@ -64,10 +59,7 @@ template <typename Range1T, typename Range2T = Range1T> bool iEquals(const Range
     const auto &first_normalized = std::is_pointer<Range1T>::value ? std::string_view(first) : first;
     const auto &second_normalized = std::is_pointer<Range1T>::value ? std::string_view(second) : second;
 
-    const auto result = std::lexicographical_compare_three_way(std::begin(first_normalized), std::end(first_normalized),
-                                                               std::begin(second_normalized), std::end(second_normalized),
-                                                               detail::cmp_icase{});
-    return std::is_eq(result);
+    return traits_cast<ichar_traits<char>>(first_normalized) == traits_cast<ichar_traits<char>>(second_normalized);
 }
 
 template <typename Range1T, typename Range2T = Range1T> bool iLess(const Range1T &first, const Range2T &second)
@@ -75,10 +67,7 @@ template <typename Range1T, typename Range2T = Range1T> bool iLess(const Range1T
     const auto &first_normalized = std::is_pointer<Range1T>::value ? std::string_view(first) : first;
     const auto &second_normalized = std::is_pointer<Range1T>::value ? std::string_view(second) : second;
 
-    const auto result = std::lexicographical_compare_three_way(std::begin(first_normalized), std::end(first_normalized),
-                                                               std::begin(second_normalized), std::end(second_normalized),
-                                                               detail::cmp_icase{});
-    return std::is_lt(result);
+    return traits_cast<ichar_traits<char>>(first_normalized) < traits_cast<ichar_traits<char>>(second_normalized);
 }
 
 template <typename Range1T, typename Range2T = Range1T> bool iLessOrEqual(const Range1T &first, const Range2T &second)
@@ -86,10 +75,7 @@ template <typename Range1T, typename Range2T = Range1T> bool iLessOrEqual(const 
     const auto &first_normalized = std::is_pointer<Range1T>::value ? std::string_view(first) : first;
     const auto &second_normalized = std::is_pointer<Range1T>::value ? std::string_view(second) : second;
 
-    const auto result = std::lexicographical_compare_three_way(std::begin(first_normalized), std::end(first_normalized),
-                                        std::begin(second_normalized), std::end(second_normalized),
-                                        detail::cmp_icase{});
-    return std::is_lt(result) || std::is_eq(result);
+    return traits_cast<ichar_traits<char>>(first_normalized) <= traits_cast<ichar_traits<char>>(second_normalized);
 }
 
 template <typename Range1T, typename Range2T = Range1T> bool iGreater(const Range1T &first, const Range2T &second)


### PR DESCRIPTION
Fixes a theoretical issue because of using `lexicographical_compare` with `<=`. This triggered a debug assertion in Visual Studio.

Replaced it with the C++20 three-way comparison, which is hopefully supported on all compilers.