### PR TITLE
Do not crash when encountering invalid characters

### DIFF
--- a/src/libs/renderer/src/font.cpp
+++ b/src/libs/renderer/src/font.cpp
@@ -3,6 +3,8 @@
 #include "storm/config.hpp"
 #include "utf8.h"
 
+#include <format>
+
 namespace
 {
 

--- a/src/libs/renderer/src/font.cpp
+++ b/src/libs/renderer/src/font.cpp
@@ -3,7 +3,7 @@
 #include "storm/config.hpp"
 #include "utf8.h"
 
-#include <format>
+#include <fmt/format.h>
 
 namespace
 {
@@ -208,7 +208,7 @@ int32_t FONT::GetStringWidth(const std::string_view &text, std::optional<float> 
         if (Codepoint > USED_CODES) {
             core.Trace("Invalid codepoint: %d", Codepoint);
             if constexpr(storm::kIsDebug) {
-                throw std::runtime_error(std::format("Invalid codepoint: {}", Codepoint));
+                throw std::runtime_error(fmt::format("Invalid codepoint: {}", Codepoint));
             }
             continue;
         }
@@ -252,7 +252,7 @@ int32_t FONT::UpdateVertexBuffer(int32_t x, int32_t y, char *data_PTR, int utf8l
         if (Codepoint > USED_CODES) {
             core.Trace("Invalid codepoint: %d", Codepoint);
             if constexpr(storm::kIsDebug) {
-                throw std::runtime_error(std::format("Invalid codepoint: {}", Codepoint));
+                throw std::runtime_error(fmt::format("Invalid codepoint: {}", Codepoint));
             }
             continue;
         }

--- a/src/libs/renderer/src/font.cpp
+++ b/src/libs/renderer/src/font.cpp
@@ -1,5 +1,6 @@
 #include "font.h"
 #include "core.h"
+#include "storm/config.hpp"
 #include "utf8.h"
 
 namespace
@@ -201,7 +202,14 @@ int32_t FONT::GetStringWidth(const std::string_view &text, std::optional<float> 
     for (int32_t i = 0; i < s_num; i += utf8::u8_inc(text.data() + i))
     {
         uint32_t Codepoint = utf8::Utf8ToCodepoint(text.data() + i);
-        Assert(Codepoint < USED_CODES);
+
+        if (Codepoint > USED_CODES) {
+            core.Trace("Invalid codepoint: %d", Codepoint);
+            if constexpr(storm::kIsDebug) {
+                throw std::runtime_error(std::format("Invalid codepoint: {}", Codepoint));
+            }
+            continue;
+        }
 
         FLOAT_RECT pos = charDescriptors_[Codepoint].Pos;
 
@@ -238,7 +246,14 @@ int32_t FONT::UpdateVertexBuffer(int32_t x, int32_t y, char *data_PTR, int utf8l
         Assert(curLetter < utf8length);
 
         int Codepoint = utf8::Utf8ToCodepoint(data_PTR + i);
-        Assert(Codepoint < USED_CODES);
+
+        if (Codepoint > USED_CODES) {
+            core.Trace("Invalid codepoint: %d", Codepoint);
+            if constexpr(storm::kIsDebug) {
+                throw std::runtime_error(std::format("Invalid codepoint: {}", Codepoint));
+            }
+            continue;
+        }
 
         n = curLetter * 6;
         FLOAT_RECT pos = charDescriptors_[Codepoint].Pos;


### PR DESCRIPTION
The engine crashes when `Font::GetStringWidth` gets called with non-UTF-8 text.

We already had some debug assertions, but this adds a bypass in release builds, so the engine does not explode.