### PR TITLE
Add `auto_pause` and `auto_mute` engine options to allow running in background

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -22,6 +22,7 @@ CorePrivate *core_private;
 constexpr char defaultLoggerName[] = "system";
 bool isRunning = false;
 bool bActive = true;
+bool bAutoMute = true;
 
 storm::diag::LifecycleDiagnosticsService lifecycleDiagnostics;
 
@@ -95,7 +96,8 @@ void HandleWindowEvent(const storm::OSWindow::Event &event)
         if (core_private->initialized())
         {
             core_private->AppState(bActive);
-            if (const auto soundService = static_cast<VSoundService *>(core.GetService("SoundService")))
+            if (const auto soundService = static_cast<VSoundService *>(core.GetService("SoundService"));
+                soundService && bAutoMute)
             {
                 soundService->SetActiveWithFade(true);
             }
@@ -107,7 +109,8 @@ void HandleWindowEvent(const storm::OSWindow::Event &event)
         if (core_private->initialized())
         {
             core_private->AppState(bActive);
-            if (const auto soundService = static_cast<VSoundService *>(core.GetService("SoundService")))
+            if (const auto soundService = static_cast<VSoundService *>(core.GetService("SoundService"));
+                soundService && bAutoMute)
             {
                 soundService->SetActiveWithFade(false);
             }
@@ -179,6 +182,7 @@ int main(int argc, char *argv[])
     int preferred_display = 0;
     bool fullscreen = false;
     bool show_borders = false;
+    bool auto_pause = true;
 
     if (ini)
     {
@@ -194,6 +198,8 @@ int main(int argc, char *argv[])
         preferred_display = ini->GetInt(nullptr, "display", 0);
         fullscreen = ini->GetInt(nullptr, "full_screen", false);
         show_borders = ini->GetInt(nullptr, "window_borders", false);
+        auto_pause = ini->GetInt(nullptr, "auto_pause", true);
+        bAutoMute = auto_pause || ini->GetInt(nullptr, "auto_mute", false);
         bSteam = ini->GetInt(nullptr, "Steam", 1) != 0;
     }
 
@@ -227,7 +233,7 @@ int main(int argc, char *argv[])
         SDL_PumpEvents();
         SDL_FlushEvents(0, SDL_LASTEVENT);
 
-        if (bActive)
+        if (bActive || !auto_pause)
         {
             if (dwMaxFPS)
             {

--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -22,7 +22,7 @@ CorePrivate *core_private;
 constexpr char defaultLoggerName[] = "system";
 bool isRunning = false;
 bool bActive = true;
-bool bAutoMute = true;
+bool bSoundInBackground = false;
 
 storm::diag::LifecycleDiagnosticsService lifecycleDiagnostics;
 
@@ -97,7 +97,7 @@ void HandleWindowEvent(const storm::OSWindow::Event &event)
         {
             core_private->AppState(bActive);
             if (const auto soundService = static_cast<VSoundService *>(core.GetService("SoundService"));
-                soundService && bAutoMute)
+                soundService && !bSoundInBackground)
             {
                 soundService->SetActiveWithFade(true);
             }
@@ -110,7 +110,7 @@ void HandleWindowEvent(const storm::OSWindow::Event &event)
         {
             core_private->AppState(bActive);
             if (const auto soundService = static_cast<VSoundService *>(core.GetService("SoundService"));
-                soundService && bAutoMute)
+                soundService && !bSoundInBackground)
             {
                 soundService->SetActiveWithFade(false);
             }
@@ -182,7 +182,7 @@ int main(int argc, char *argv[])
     int preferred_display = 0;
     bool fullscreen = false;
     bool show_borders = false;
-    bool auto_pause = true;
+    bool run_in_background = false;
 
     if (ini)
     {
@@ -198,8 +198,8 @@ int main(int argc, char *argv[])
         preferred_display = ini->GetInt(nullptr, "display", 0);
         fullscreen = ini->GetInt(nullptr, "full_screen", false);
         show_borders = ini->GetInt(nullptr, "window_borders", false);
-        auto_pause = ini->GetInt(nullptr, "auto_pause", true);
-        bAutoMute = auto_pause || ini->GetInt(nullptr, "auto_mute", false);
+        run_in_background = ini->GetInt(nullptr, "run_in_background ", false);
+        bSoundInBackground = (!run_in_background) || ini->GetInt(nullptr, "sound_in_background ", true);
         bSteam = ini->GetInt(nullptr, "Steam", 1) != 0;
     }
 
@@ -233,7 +233,7 @@ int main(int argc, char *argv[])
         SDL_PumpEvents();
         SDL_FlushEvents(0, SDL_LASTEVENT);
 
-        if (bActive || !auto_pause)
+        if (bActive || run_in_background)
         {
             if (dwMaxFPS)
             {

--- a/src/libs/pcs_controls/include/pcs_controls.h
+++ b/src/libs/pcs_controls/include/pcs_controls.h
@@ -26,6 +26,7 @@ struct SYSTEM_CONTROL_ELEMENT
 class PCS_CONTROLS : public CONTROLS
 {
     bool m_bLockAll;
+    bool updateCursor_ = true;
 
     float fMouseSensivityX;
     float fMouseSensivityY;

--- a/src/libs/pcs_controls/src/pcs_controls.cpp
+++ b/src/libs/pcs_controls/src/pcs_controls.cpp
@@ -53,6 +53,7 @@ PCS_CONTROLS::~PCS_CONTROLS()
 
 void PCS_CONTROLS::AppState(bool state)
 {
+    updateCursor_ = state;
     if (state)
     {
         // RECT r;
@@ -435,17 +436,23 @@ void PCS_CONTROLS::Update(uint32_t DeltaTime)
 {
 #ifdef _WIN32
     static int nMouseXPrev, nMouseYPrev;
-    POINT point;
-    GetCursorPos(&point);
+    if (updateCursor_) {
+        POINT point;
+        GetCursorPos(&point);
 
-    nMouseDx = point.x - nMouseXPrev;
-    nMouseDy = point.y - nMouseYPrev;
+        nMouseDx = point.x - nMouseXPrev;
+        nMouseDy = point.y - nMouseYPrev;
 
-    RECT r;
-    GetWindowRect(static_cast<HWND>(core.GetWindow()->OSHandle()), &r);
-    nMouseXPrev = r.left + (r.right - r.left) / 2;
-    nMouseYPrev = r.top + (r.bottom - r.top) / 2;
-    SetCursorPos(nMouseXPrev, nMouseYPrev);
+        RECT r;
+        GetWindowRect(static_cast<HWND>(core.GetWindow()->OSHandle()), &r);
+        nMouseXPrev = r.left + (r.right - r.left) / 2;
+        nMouseYPrev = r.top + (r.bottom - r.top) / 2;
+        SetCursorPos(nMouseXPrev, nMouseYPrev);
+    }
+    else {
+        nMouseDx = 0;
+        nMouseDy = 0;
+    }
 #endif
 
     m_ControlTree.Process();


### PR DESCRIPTION
Adds two options to the `engine.ini`:

- `auto_pause`: Wether the game should be paused when the window loses focus. Default = `true`.
- `auto_mute`: Wether the audio should be muted when the window loses focus. Default = `false`, only checked when `auto_pause` is disabled.