### PR TITLE
Revert "ci: remove old conan workaround from Linux CI"

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -52,6 +52,9 @@ jobs:
         export CXX=clang++-12
         ${CXX} --version
         mkdir build && cd build
+        conan profile new default --detect
+        conan profile update conf.tools.system.package_manager:mode=install default
+        conan profile update conf.tools.system.package_manager:sudo=True default
         cmake .. -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.configuration}}
     - name: Build dependencies
       run: ninja dependencies


### PR DESCRIPTION
This reverts commit 1611d310602cf78ddacd423f280a4a99602810f1.

Looks like this is still useful conan settings.