### PR TITLE
Prevent crashes when running an empty project in fullscreen mode

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -245,7 +245,7 @@ int main(int argc, char *argv[])
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
 
-        if (core.Controls->GetDebugAsyncKeyState(VK_F1) && core.Controls->GetDebugAsyncKeyState(VK_SHIFT))
+        if (core.Controls && core.Controls->GetDebugAsyncKeyState(VK_F1) && core.Controls->GetDebugAsyncKeyState(VK_SHIFT))
         {
             mi_stats_print_out(mimalloc_fun, nullptr);
             std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/src/libs/core/src/core_impl.cpp
+++ b/src/libs/core/src/core_impl.cpp
@@ -505,8 +505,10 @@ void *CoreImpl::GetService(const char *service_name)
     const auto class_code = MakeHashValue(service_name);
     pClass->SetHash(class_code);
 
-    if (!service_PTR->Init())
+    if (!service_PTR->Init()) {
         CheckAutoExceptions(0);
+        return nullptr;
+    }
 
     Services_List.Add(class_code, class_code, service_PTR);
 

--- a/src/libs/sound_service/src/sound_service.cpp
+++ b/src/libs/sound_service/src/sound_service.cpp
@@ -80,6 +80,10 @@ bool SoundService::Init()
 
     rs = static_cast<VDX9RENDER *>(core.GetService("DX9RENDER"));
 
+    if (rs == nullptr) {
+        return false;
+    }
+
     CHECKFMODERR(FMOD::System_Create(&system));
     unsigned version;
     CHECKFMODERR(system->getVersion(&version));
@@ -824,6 +828,10 @@ void SoundService::SetActiveWithFade(const bool active)
 {
     if (fadeTimeInSeconds == 0.0f)
     {
+        return;
+    }
+
+    if (system == nullptr) {
         return;
     }
 


### PR DESCRIPTION
If you create an "empty" project with the following files:

**engine.ini**
```
run = main.c

full_screen = 1
screen_x = 1920
screen_y = 1080
```

**main.c** 
```
object Render;

int iScriptVersion = 54128;

void Main() {}
```
the engine would crash if you tabbed out.

This was caused by the fact that no services get initialized by the script, but upon losing focus the sound service is requested to mute the audio.
This will then request the render service, which fails to create because it is running in unfocused full-screen mode.

Not a very useful or common scenario, but it's always better for things not to crash.