### PR TITLE
Create shared controls header

### DIFF
--- a/src/libs/core/include/controls.h
+++ b/src/libs/core/include/controls.h
@@ -1,15 +1,12 @@
 #pragma once
 
+#include <shared/controls.h>
+
 #include "utf8.h"
 #include <cstdint>
 
 #define INVALID_CONTROL_CODE 0xffffffff
 #define UNASSIGNED_CONTROL 0xffffffff
-
-// control flags
-#define USE_AXIS_AS_BUTTON 0x1
-#define USE_AXIS_AS_INVERSEBUTTON 0x2
-#define INVERSE_CONTROL 0x4
 
 struct DEVICE_DESC
 {

--- a/src/libs/pcs_controls/include/pcs_controls.h
+++ b/src/libs/pcs_controls/include/pcs_controls.h
@@ -3,6 +3,8 @@
 #include "control_tree.h"
 #include "key_buffer.h"
 
+#include <shared/controls.h>
+
 #include <memory>
 
 namespace storm
@@ -18,10 +20,6 @@ struct SYSTEM_CONTROL_ELEMENT
 };
 
 #define CONTROL_ELEMENTS_NUM 260
-#define CE_MOUSE_X_AXIS 256
-#define CE_MOUSE_Y_AXIS 257
-#define CE_MOUSE_WHEEL_UP 258
-#define CE_MOUSE_WHEEL_DOWN 259
 
 class PCS_CONTROLS : public CONTROLS
 {

--- a/src/libs/shared_headers/include/shared/controls.h
+++ b/src/libs/shared_headers/include/shared/controls.h
@@ -1,0 +1,15 @@
+#ifndef COMMON_CONTROLS_HPP
+#define COMMON_CONTROLS_HPP
+
+// Special key codes
+#define CE_MOUSE_X_AXIS 256
+#define CE_MOUSE_Y_AXIS 257
+#define CE_MOUSE_WHEEL_UP 258
+#define CE_MOUSE_WHEEL_DOWN 259
+
+// Control flags
+#define USE_AXIS_AS_BUTTON 1
+#define USE_AXIS_AS_INVERSEBUTTON 2
+#define INVERSE_CONTROL 4
+
+#endif


### PR DESCRIPTION
Moved some constants to a shared `controls.h` header, so we don't have to redefine them in the game scripts.