### PR TITLE
Fix nullptr exception during Fader init

### DIFF
--- a/src/libs/core/src/entity_manager.cpp
+++ b/src/libs/core/src/entity_manager.cpp
@@ -203,6 +203,8 @@ void EntityManager::EraseAll()
 
     // clear cache
     cache_.Clear();
+
+    previousStamp_ = 0;
 }
 
 entptr_t EntityManager::GetEntityPointer(const entid_t id) const
@@ -315,12 +317,7 @@ entid_t EntityManager::CalculateEntityId(const size_t idx)
     // assert for idx exceeding 2^32
     assert(static_cast<size_t>(static_cast<uint32_t>(idx)) == idx);
 
-    // calculate stamp
-    const auto ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
-
-    // assemble entity id
-    const auto stamp = static_cast<entid_stamp_t>(ms.count());
+    const auto stamp = ++previousStamp_;
     const auto id = static_cast<entid_t>(stamp) << 32 | idx;
 
     return id;

--- a/src/libs/core/src/entity_manager.h
+++ b/src/libs/core/src/entity_manager.h
@@ -71,7 +71,7 @@ class EntityManager final
     };
 
     static bool EntIdxValid(size_t idx);
-    static entid_t CalculateEntityId(size_t idx);
+    entid_t CalculateEntityId(size_t idx);
 
     size_t GetEntityDataIdx(entid_t id) const;
     entid_t GetEntityId(uint32_t hash) const;
@@ -95,4 +95,6 @@ class EntityManager final
 
     // stack of entities for deferred delete
     plf::stack<entity_index_t> deletedIndices_;
+
+    entid_stamp_t previousStamp_ = 0;
 };


### PR DESCRIPTION
Fixes a nullptr exception.

Also took the opportunity to add a small template function for more easily getting Entities.

Should fix https://github.com/PiratesAhoy/new-horizons/issues/91