### PR TITLE
Fixed perspective on ultrawide screens

### DIFF
--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -2094,30 +2094,17 @@ void DX9RENDER::SetNearFarPlane(float fNear, float fFar)
 
 bool DX9RENDER::SetPerspective(float perspective, float fAspectRatio)
 {
-    perspective *= FovMultiplier;
+    if (fAspectRatio < 0)
+    {
+         fAspectRatio = static_cast<float>(screen_size.x) / screen_size.y;
+    }
 
     const float near_plane = fNearClipPlane; // Distance to near clipping
     const float far_plane = fFarClipPlane;   // Distance to far clipping
-    const float fov_horiz = perspective;     // Horizontal field of view  angle, in radians
-    if (fAspectRatio < 0)
-    {
-        fAspectRatio = static_cast<float>(screen_size.y) / screen_size.x;
-    }
-    aspectRatio = fAspectRatio;
-    const float fov_vert =
-        2.f * atanf(tanf(perspective / 2.f) * fAspectRatio); // Vertical field of view  angle, in radians
+    const float fov_vert = 2.0f * atanf(tanf(perspective * 0.5f * FovMultiplier) / fAspectRatio);
 
-    const float w = 1.0f / tanf(fov_horiz * 0.5f);
-    const float h = 1.0f / tanf(fov_vert * 0.5f);
-    const float Q = far_plane / (far_plane - near_plane);
-
-    D3DMATRIX mtx{};
-
-    mtx._11 = w;
-    mtx._22 = h;
-    mtx._33 = Q;
-    mtx._43 = -Q * near_plane;
-    mtx._34 = 1.0f;
+    D3DXMATRIX mtx{};
+    D3DXMatrixPerspectiveFovLH(&mtx, fov_vert, fAspectRatio, near_plane, far_plane);
 
     if (CHECKD3DERR(d3d9->SetTransform(D3DTS_PROJECTION, &mtx)) == true)
         return false;

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -2094,29 +2094,17 @@ void DX9RENDER::SetNearFarPlane(float fNear, float fFar)
 
 bool DX9RENDER::SetPerspective(float perspective, float fAspectRatio)
 {
-    perspective *= FovMultiplier;
+    if (fAspectRatio < 0)
+    {
+         fAspectRatio = static_cast<float>(screen_size.x) / screen_size.y;
+    }
 
     const float near_plane = fNearClipPlane; // Distance to near clipping
     const float far_plane = fFarClipPlane;   // Distance to far clipping
-    const float fov_horiz = perspective;     // Horizontal field of view  angle, in radians
-    if (fAspectRatio < 0)
-    {
-        fAspectRatio = static_cast<float>(screen_size.y) / screen_size.x;
-    }
-    aspectRatio = fAspectRatio;
-    const float fov_vert = perspective * fAspectRatio; // Vertical field of view  angle, in radians
+    const float fov_vert = 2.0f * atanf(tanf(perspective * 0.5f * FovMultiplier) / fAspectRatio);
 
-    const float w = 1.0f / tanf(fov_horiz * 0.5f);
-    const float h = 1.0f / tanf(fov_vert * 0.5f);
-    const float Q = far_plane / (far_plane - near_plane);
-
-    D3DMATRIX mtx{};
-
-    mtx._11 = w;
-    mtx._22 = h;
-    mtx._33 = Q;
-    mtx._43 = -Q * near_plane;
-    mtx._34 = 1.0f;
+    D3DXMATRIX mtx{};
+    D3DXMatrixPerspectiveFovLH(&mtx, fov_vert, fAspectRatio, near_plane, far_plane);
 
     if (CHECKD3DERR(d3d9->SetTransform(D3DTS_PROJECTION, &mtx)) == true)
         return false;

--- a/src/libs/renderer/src/s_device.cpp
+++ b/src/libs/renderer/src/s_device.cpp
@@ -2094,17 +2094,30 @@ void DX9RENDER::SetNearFarPlane(float fNear, float fFar)
 
 bool DX9RENDER::SetPerspective(float perspective, float fAspectRatio)
 {
-    if (fAspectRatio < 0)
-    {
-         fAspectRatio = static_cast<float>(screen_size.x) / screen_size.y;
-    }
+    perspective *= FovMultiplier;
 
     const float near_plane = fNearClipPlane; // Distance to near clipping
     const float far_plane = fFarClipPlane;   // Distance to far clipping
-    const float fov_vert = 2.0f * atanf(tanf(perspective * 0.5f * FovMultiplier) / fAspectRatio);
+    const float fov_horiz = perspective;     // Horizontal field of view  angle, in radians
+    if (fAspectRatio < 0)
+    {
+        fAspectRatio = static_cast<float>(screen_size.y) / screen_size.x;
+    }
+    aspectRatio = fAspectRatio;
+    const float fov_vert =
+        2.f * atanf(tanf(perspective / 2.f) * fAspectRatio); // Vertical field of view  angle, in radians
 
-    D3DXMATRIX mtx{};
-    D3DXMatrixPerspectiveFovLH(&mtx, fov_vert, fAspectRatio, near_plane, far_plane);
+    const float w = 1.0f / tanf(fov_horiz * 0.5f);
+    const float h = 1.0f / tanf(fov_vert * 0.5f);
+    const float Q = far_plane / (far_plane - near_plane);
+
+    D3DMATRIX mtx{};
+
+    mtx._11 = w;
+    mtx._22 = h;
+    mtx._33 = Q;
+    mtx._43 = -Q * near_plane;
+    mtx._34 = 1.0f;
 
     if (CHECKD3DERR(d3d9->SetTransform(D3DTS_PROJECTION, &mtx)) == true)
         return false;


### PR DESCRIPTION
In the **SetPerspective** function, the variable **perspective** is the horizontal fov, which is set to the same value for all diagonals, and as the screen width increases, the image gets closer. For example, the horizontal fov is 90 and with an aspect ratio of 16:9 vertical fov = 59, and with an aspect ratio of 21:9 vertical fov = 47. https://themetalmuncher.github.io/fov-calc/
The perspective can be increased using the **fov_multiplier** variable in the **engine.ini** file, but after that the image looks distorted. Look at the screenshot with the barrel, without changes it is not round but oval.
Instead of manually calculating perspective projection matrix, i used this function https://learn.microsoft.com/en-us/windows/win32/direct3d9/d3dxmatrixperspectivefovlh

**Without fix fov_multiplier = 1.0**
![default-1 0](https://user-images.githubusercontent.com/29454172/236563527-b753a6ca-0132-46f8-ad81-42f6b2eaf492.jpg)
**With fix fov_multiplier = 1.0**
![moded-1 0](https://user-images.githubusercontent.com/29454172/236563584-c2797fc6-1e6c-4fb6-9f28-3ac0c334fc8b.jpg)

**Without fix fov_multiplier = 1.5**
![default2-1 5](https://user-images.githubusercontent.com/29454172/236564992-dc149df5-f7aa-4165-a3c3-166c186ba989.jpg)
**With fix fov_multiplier = 1.5**
![moded2-1 5](https://user-images.githubusercontent.com/29454172/236565018-f75e35b4-b7d2-40ba-a6c7-c7f29bda7558.jpg)

**Without fix fov_multiplier = 1.5**
![default-1 5-circle](https://user-images.githubusercontent.com/29454172/236563700-98341def-3b8b-4ddd-8ae3-681d9aece5f6.jpg)
**With fix fov_multiplier = 1.5**
![moded-1 5-circle](https://user-images.githubusercontent.com/29454172/236563725-4524a643-8bb9-4aed-bfa8-41bfa5ba64ae.jpg)
