### PR TITLE
linux: disable mimalloc statistics writing after exiting main (part 2)

### DIFF
--- a/src/apps/engine/src/main.cpp
+++ b/src/apps/engine/src/main.cpp
@@ -264,6 +264,8 @@ int main(int argc, char *argv[])
     core_private->ReleaseBase();
 #ifdef _WIN32 // FIX_LINUX Cursor
     ClipCursor(nullptr);
+#elif _DEBUG
+    mi_option_set(mi_option_verbose, 0); // disable statistics writing in Linux
 #endif
     SDL_Quit();
 


### PR DESCRIPTION
mimalloc will write statistics when any of these conditions are met:
```
if (mi_option_is_enabled(mi_option_show_stats) || mi_option_is_enabled(mi_option_verbose)) {
  mi_stats_print(NULL);
}
```
https://github.com/microsoft/mimalloc/blob/2cbf68b5e74ac00c585a48c5b82dff6b87fbf9e3/src/init.c#L646

`mi_option_is_enabled(mi_option_show_stats)` was false after this PR: https://github.com/storm-devs/storm-engine/pull/361
`mi_option_is_enabled(mi_option_verbose)` was always false on Linux because it never defined _DEBUG until: https://github.com/storm-devs/storm-engine/pull/452

So I just disabled 2nd condition in Linux before exiting `int main`.