### PR TITLE
Fix string count not being reset when resetting string codec

### DIFF
--- a/src/libs/core/src/string_codec.h
+++ b/src/libs/core/src/string_codec.h
@@ -53,6 +53,7 @@ class STRING_CODEC : public VSTRING_CODEC
             HTable[m].pElements = nullptr;
             HTable[m].nStringsNum = 0;
         }
+        nStringsNum = 0;
     }
 
     uint32_t Convert(const char *pString, int32_t iLen) override


### PR DESCRIPTION
Found a bug where the string count does not actually match the number of string in a string codec. Caused by the count not being reset, this resulted in a lot of empty strings being stored in save games.