### PR TITLE
Re-enables using the ability menu in the sea battle interface

### DIFF
--- a/src/libs/battle_interface/src/sea/battle_ship_command.cpp
+++ b/src/libs/battle_interface/src/sea/battle_ship_command.cpp
@@ -54,6 +54,9 @@ void BIShipCommandList::FillIcons()
         if (check(BI_COMMODE_USER_ICONS))
             nIconsQuantity += UserIconsAdding();
 
+        if (check(BI_COMMODE_ABILITY_ICONS))
+            nIconsQuantity += AbilityAdding();
+
         if (check(BI_COMMODE_ENEMY_TOWN))
             nIconsQuantity +=
                 TownAdding((m_nCurrentCommandMode & BI_COMMODE_ALLLOCATOR_SELECT) != 0, true, true, true, false, false);


### PR DESCRIPTION
Apparently the ability sub-menu was disabled for the sea battle interface.

I re-enabled it. Don't think this should break anything else, as it should not do anything if you don't use the ability menu.