### PR TITLE
Fix order-of-operation bug in triangle sail distance calculation

### DIFF
--- a/src/libs/rigging/src/sailone.cpp
+++ b/src/libs/rigging/src/sailone.cpp
@@ -2067,6 +2067,6 @@ float SAILONE::GetDistanceFromPointTo3Point(const CVECTOR &v, const CVECTOR &vB1
     const CVECTOR vN = !((vB1 - vB2) ^ (vB3 - vB2));
     const float fD = -(vN | vB2);
 
-    const float f = v | vN + fD;
+    const float f = (v | vN) + fD;
     return f;
 }


### PR DESCRIPTION
Investigating a bug causing triangle sails to stretch out, I found an order-of-operation bug in the point-to-triangle-distance code.

Fixes https://github.com/PiratesAhoy/new-horizons/issues/82