### PR TITLE
Fix IsEntity sometimes returning true for previously deleted entities

### DIFF
--- a/src/libs/core/src/internal_functions.cpp
+++ b/src/libs/core/src/internal_functions.cpp
@@ -1626,6 +1626,10 @@ DATA *COMPILER::BC_CallIntFunction(uint32_t func_code, DATA *&pVResult, uint32_t
         }
         pV->Get(ent);
         core.EraseEntity(ent);
+
+        // Make sure to clear entity id
+        ent = invalid_entity;
+        pV->Set(ent);
         break;
         //
     case FUNC_DEL_EVENT_HANDLER:


### PR DESCRIPTION
When deleting an entity, saving the game and then loading that save game, it is possible for a newly created entity to have the same id as the old deleted entity id.

If the old entity variable is not yet overwritten, it will then return true for `IsEntity(&entity)`.

This can be fixed by making sure the variable value is reset after calling `DeleteEntity`

Also fixes https://github.com/PiratesAhoy/new-horizons/issues/141