### PR TITLE
[Conan] Copy the correct version of `mimalloc.dll` in Debug configuration

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -63,11 +63,7 @@ class StormEngine(ConanFile):
             if self.options.steam:
                 self.__install_lib("steam_api64.dll")
 
-            self.__install_bin("mimalloc-redirect.dll")
-            if self.settings.build_type == "Debug":
-                self.__install_bin("mimalloc-debug.dll")
-            else:
-                self.__install_bin("mimalloc.dll")
+            self.__install_bin("mimalloc*.dll") # mimalloc, mimalloc-redirect, mimalloc-debug, etc.
 
         else: # not Windows
             if self.settings.build_type == "Debug":


### PR DESCRIPTION
### Overview
The name of the mimalloc shared library might depend not only on the current configuration type (Debug/Release), but also on the CMake generator that Conan is using to configure/build dependencies. For instance, in my environment Conan is using "Visual Studio 17 2022" multi-config CMake generator, which results in the library named `mimalloc.dll` for both Debug and Release configurations. However it looks like if Conan would use a single-config CMake generator, then the library name for the Debug configuration would be `mimalloc-debug.dll`

This leads to an issue where `mimalloc.dll` wouldn't be copied to the output directory in the Debug configuration, and there would be the "mimalloc.dll was not found" runtime error on start

### Solution
The simplest way to copy the right DLL seems to be using the wildcard to copy all available mimalloc DLLs. That would automatically include `mimalloc-redirect.dll` as well (tagging @espkk for visibility)

### Tests
Tested on Windows, Visual Studio 2022. Library recompilation can be tested by removing mimalloc from Conan cache (`conan remove mimalloc`)
Would be glad if someone could double-check if this fix doesn't break anything else