### PR TITLE
Fix dynamic call screwing up values

### DIFF
--- a/src/libs/core/src/compiler.cpp
+++ b/src/libs/core/src/compiler.cpp
@@ -4456,6 +4456,7 @@ bool COMPILER::BC_Execute(uint32_t function_code, DATA *&pVReturnResult, const c
             pVResult = nullptr;
             if (!BC_CallFunction(func_code, ip, pVResult))
                 return false;
+            ExpressionResult.ClearType();
             if (pVResult)
             {
                 ExpressionResult.Set(1);


### PR DESCRIPTION
ExpressionResult may contain a reference to an object after returning from BC_CallFunction. Script example that insta crashes the game before this fix (most of the time, sometimes it hides MC's portrait):
```
void Suicide()
{
	ref sld = CharacterFromID("Blaze");
}

void ActiveF10Control()
{
	string death = "Suicide";
	call death();
}
```
`Suicide()` caused ExpressionResult to have a reference to an object (reference to main character). `ExpressionResult.Set(0);` sets the object's type to int which is obviously bad.