### PR TITLE
Fix Linux CI

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -55,7 +55,7 @@ jobs:
         conan profile new default --detect
         conan profile update conf.tools.system.package_manager:mode=install default
         conan profile update conf.tools.system.package_manager:sudo=True default
-        cmake .. -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.configuration}}
+        cmake .. -DSTORM_USE_CONAN_SDL=OFF -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.configuration}}
     - name: Build dependencies
       run: ninja dependencies
       working-directory: build

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -48,8 +48,8 @@ jobs:
       run: pip install conan==1.59.0
     - name: Configure with cmake
       run: |
-        export CC=clang-12
-        export CXX=clang++-12
+        export CC=clang-15
+        export CXX=clang++-15
         ${CXX} --version
         mkdir build && cd build
         conan profile new default --detect

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class StormEngine(ConanFile):
 
     # dependencies used in deploy binaries
     # conan-center
-    requires = ["zlib/1.2.13", "spdlog/1.9.2", "fast_float/3.4.0", "mimalloc/2.0.3", "sentry-native/0.5.0",
+    requires = ["zlib/1.2.13", "spdlog/1.9.2", "fast_float/3.4.0", "mimalloc/2.0.3", "sentry-native/0.6.5",
     # storm.jfrog.io
     "directx/9.0@storm/prebuilt", "fmod/2.02.05@storm/prebuilt"]
     # aux dependencies (e.g. for tests)


### PR DESCRIPTION
Main goal of PR - fix Linux CI. Clang 12 was removed from Ubuntu 22.04 CI image: https://github.com/actions/runner-images/issues/8263
1. Update to clang-15 fixed one error.
2. Building SDL and Pulseaudio from source is painfull (for CI, for me and most likely for everyone), so I added `-DSTORM_USE_CONAN_SDL=OFF` to CI. That fixed other error ( https://github.com/q4a/storm-engine/actions/runs/6955795354/job/18925323436 ):
```
checking whether C compiler accepts -std=gnu11... no
configure: error: *** Compiler does not support -std=gnu11
pulseaudio/14.2: ERROR: Package '22ea332a91486ebf9a840891f08bf8676c078958' build failed
pulseaudio/14.2: WARN: Build folder /home/runner/.conan/data/pulseaudio/14.2/_/_/build/22ea332a91486ebf9a840891f08bf8676c078958/build-debug
pulseaudio/14.2: 
ERROR: pulseaudio/14.2: Error in build() method, line 127
	autotools.configure()
	ConanException: Error 1 while executing "/home/runner/.conan/data/pulseaudio/14.2/_/_/build/22ea332a91486ebf9a840891f08bf8676c078958/src/configure" '--disable-shared' '--enable-static' '--prefix=/' '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' '--libdir=${prefix}/lib' '--includedir=${prefix}/include' '--oldincludedir=${prefix}/include' '--enable-shared=no' '--enable-static=yes' '--enable-glib2=no' '--with-fftw=no' '--with-udev-rules-dir=${prefix}/bin/udev/rules.d' '--with-systemduserunitdir=/home/runner/.conan/data/pulseaudio/14.2/_/_/build/22ea332a91486ebf9a840891f08bf8676c078958/build-debug/ignore' '--enable-alsa=yes' '--enable-x11=yes' '--enable-openssl=yes' '--enable-dbus=no' '--libexecdir=${prefix}/bin' 
CMake Error at cmake/conan.cmake:524 (message):
  Conan install failed='1'
Call Stack (most recent call first):
  cmake/conan.cmake:761 (old_conan_cmake_install)
  CMakeLists.txt:36 (conan_cmake_run)
```
3. And Looks like sentry-native 0.5.0 is very old and gives error on clang-15. So I updated it to 0.6.5. @espkk or @Hammie , can you check  that Windows builds works fine with sentry-native 0.6.5?
That fixed last error ( https://github.com/q4a/storm-engine/actions/runs/6956073134/job/18926156721 ):
```
[  3%] Building CXX object third_party/mini_chromium/CMakeFiles/mini_chromium.dir/mini_chromium/base/logging.cc.o
In file included from /home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/files/file_path.cc:10:
/home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h:23:28: error: unknown type name 'uint32_t'
using LoggingDestination = uint32_t;
                           ^
/home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h:29:8: error: unknown type name 'LoggingDestination'
enum : LoggingDestination {
       ^
/home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h:47:3: error: unknown type name 'LoggingDestination'
  LoggingDestination logging_dest = LOG_DEFAULT;
  ^
3 errors generated.
gmake[2]: *** [third_party/mini_chromium/CMakeFiles/mini_chromium.dir/build.make:90: third_party/mini_chromium/CMakeFiles/mini_chromium.dir/mini_chromium/base/files/file_path.cc.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
In file included from /home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.cc:5:
/home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h:23:28: error: unknown type name 'uint32_t'
using LoggingDestination = uint32_t;
                           ^
/home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h:29:8: error: unknown type name 'LoggingDestination'
enum : LoggingDestination {
       ^
/home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h:47:3: error: unknown type name 'LoggingDestination'
  LoggingDestination logging_dest = LOG_DEFAULT;
  ^
[  4%] Linking CXX static library libcrashpad_tools.a
[  4%] Built target crashpad_tools
/home/runner/.conan/data/sentry-crashpad/0.5.0/_/_/build/c27994f4d7c794e87ef6de1008b4fa3af02a710c/src/external/crashpad/third_party/mini_chromium/mini_chromium/base/logging.cc:76:1: error: unknown type name 'LoggingDestination'
LoggingDestination g_logging_destination = LOG_DEFAULT;
^
4 errors generated.
```